### PR TITLE
Tee build logs and cat them before grepping

### DIFF
--- a/.github/workflows/cd--preview-netlify.yml
+++ b/.github/workflows/cd--preview-netlify.yml
@@ -27,6 +27,6 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
-          netlify deploy --dir=build --build --context deploy-preview > logs.txt
-          PREVIEW_URL="$(grep "Website Draft URL" | awk -F'Website Draft URL: ' '{print $2}')"
+          netlify deploy --dir=build --build --context deploy-preview | tee logs.txt
+          PREVIEW_URL="$(cat logs.txt | grep "Website Draft URL" | awk -F'Website Draft URL: ' '{print $2}')"
           echo "::set-output name=url::\"$PREVIEW_URL\""


### PR DESCRIPTION
- Forgot to cat the logs before grepping the URL. 
- Tee instead of outputing to file directly to keep logs in console