### PR TITLE
Set DFX version to latest

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "dfx": "0.9.2",
   "canisters": {
     "portal": {
       "portal": {


### PR DESCRIPTION
The version was specified in `dfx.json`. Remove the line to always use the latest one (latest is already installed with CD)