### PR TITLE
Old page redirects to new site

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,7 +1,7 @@
 
 /docs/base-libraries/* /docs/current/references/motoko-ref/:splat 301
 /docs/release-notes/* /docs/current/developer-docs/good-to-know/release-notes/:splat 301
-/docs/developers-guide/* /docs/current/references/cli-reference/:splat 301
+/docs/developers-guide/cli-reference/* /docs/current/references/cli-reference/:splat 301
 
 
 # /docs/candid-guide/candid-concepts.html


### PR DESCRIPTION
Add `/static/_redirects` file to redirect the old URL structure on smartcontracts.org to the new pages. This utilizes Netlify's [redirect rules](https://docs.netlify.com/routing/redirects/).

* redirect Motoko standard library, eg. [HashMap](https://smartcontracts.org/docs/base-libraries/HashMap.html) => [HashMap](https://6266c8aee48037353c72b89a--icportal-pre-release.netlify.app/docs/base-libraries/HashMap.html)
* redirect release notes, eg. [0.9.3](https://smartcontracts.org/docs/release-notes/0.9.3-rn.html) => [0.9.3](https://6266c8aee48037353c72b89a--icportal-pre-release.netlify.app/docs/release-notes/0.9.3-rn.html)
* CLI reference eg. [dfx start](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-start.html) => [dfx start](https://6266c8aee48037353c72b89a--icportal-pre-release.netlify.app/docs/developers-guide/cli-reference/dfx-start.html)




