### PR TITLE
mention os requirements and simplify WSL instructions

### DIFF
--- a/docs/developer-docs/build/install-upgrade-remove.md
+++ b/docs/developer-docs/build/install-upgrade-remove.md
@@ -1,10 +1,15 @@
 # Installing the SDK
 
-As described in the [Quick start](../quickstart/hello10mins.md), you can download and install the latest version of the DFINITY Canister smart contract SDK package by running the command below in a terminal shell. The topics in this section provide additional information about installing, upgrading, and removing the SDK.
+As described in the [Quick start](../quickstart/hello10mins.md), you can download and install the latest version of the DFINITY Canister smart contract SDK, called `dfx`, by running the command below in your terminal. The topics in this section provide additional information about installing, upgrading, and removing the SDK.
 
-Command to install the SDK:
+`dfx` is supported on Linux or macOS 12.\* Monterey or later. To install `dfx`, run
 
-    $ sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+``` bash
+sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+```
+
+You can also run `dfx` on Windows using [Windows Subsystem for Linux (WSL)](../quickstart/windows-wsl).
+
 
 ## What gets installed
 

--- a/docs/developer-docs/ic-overview.md
+++ b/docs/developer-docs/ic-overview.md
@@ -4,11 +4,14 @@ Hello there!
 
 If you’ve landed here, you’re interested in learning more about the Internet Computer. You’re in the right place — take a look below for where to get started!
 
-To download the Internet Computer SDK, run the following command in your terminal.
+To download the Internet Computer SDK, run the following command in your Linux or macOS terminal:
 
 ``` bash
 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 ```
+
+[Installing the SDK](build/install-upgrade-remove) provides more detailed installation instructions, including how to run the SDK on Windows using the Windows Subsystem for Linux (WSL).
+
 
 <div class="note">
 

--- a/docs/developer-docs/quickstart/hello10mins.md
+++ b/docs/developer-docs/quickstart/hello10mins.md
@@ -8,13 +8,9 @@ Before starting, take a look at a version of this dapp running on-chain: <https:
 In this tutorial, you will learn how to:
 
 1.  Install the Canister SDK
-
 2.  Build and deployed a dapp locally
-
 3.  Collect free cycles to power your dapp
-
 4.  Create a "cycles wallet" from which you can transfer cycles to any other dapps you want to power
-
 5.  Deploy a dapp on-chain
 
 This simple `Hello` dapp is composed of two [canister smart contracts](https://wiki.internetcomputer.org/wiki/Glossary#C) (one for backend and one for frontend). The dapp accepts a text argument as input and returns a greeting. For example, if you call the `greet` method with the text argument `Everyone` on the command-line via the canister SDK (see instructions below on how to install the canister SDK), the dapp will return `Hello, Everyone!` either in your terminal:
@@ -30,6 +26,8 @@ Or via the dapp in a browser, a pop-up window will appear with the message: `Hel
 
 Note that the "Hello World" dapp consists of back-end code written in [Motoko](../build/languages/motoko/), a programming language specifically designed for interacting with the IC, and a simple webpack-based front-end.
 
+This tutorial requires Linux, macOS 12.\* Monterey or later, or Windows with a [Windows Subsystem for Linux (WSL)](windows-wsl) installation.
+
 ## Topics Covered in this Tutorial
 
 -   **Canisters** are the smart contracts installed on the IC. They contain the code to be ran and a state, which is produced as a result of running the code. As is the case of the "Hello World" dapp, it is common for dapps to be composed of multiple canisters.
@@ -38,19 +36,13 @@ Note that the "Hello World" dapp consists of back-end code written in [Motoko](.
 
 -   A **[cycles wallet](../build/project-setup/default-wallet)** is a canister that holds cycles and powers up dapps.
 
-## Supported operating systems
-This tutorial requires one of the following operating systems
-- Linux
-- macOS (12.\* Monterey)
-- Windows (With [WSL installed](windows-wsl))
-
 ## 1. Installing Tools
 
-To complete the Hello World tutorial and generally to build and deploy canisters, users need to install the canister SDK, Node.js and the Node package manager.
+To build and deploy the `Hello` dapp, you need to install the following tools.
 
-### 1.1 DFX
+### DFX
 
-In this tutorial, we use a Canister SDK called `dfx`, which is the default SDK maintained by the DFINITY foundation. There are other SDKs and this is just one which is written in Motoko.
+In this tutorial, we use a Canister SDK called `dfx`, which is the default SDK maintained by the DFINITY foundation. 
 
 To install `dfx`, run:
 
@@ -68,7 +60,9 @@ The terminal should look like this (at least version 0.9.2):
 
 ![dfx version](_attachments/dfx-version.png)
 
-### 1.2 Node.js
+More installation options and instructions for uninstalling `dfx` are covered in [Installing the SDK](../build/install-upgrade-remove).
+
+### Node.js
 
 Node.js is necessary for rendering the frontend assets and so is necessary to complete this tutorial. Note however that Node.js in not needed for canister development in general.
 

--- a/docs/developer-docs/quickstart/windows-wsl.md
+++ b/docs/developer-docs/quickstart/windows-wsl.md
@@ -1,37 +1,35 @@
 # Installing DFX on Windows
 
-There is no native Windows version of `dfx`, you need Windows Subsystem for Linux (AKA “WSL”) as the prerequisite.
+There is no native support for `dfx` on Windows. However, by installing the Windows Subsystem for Linux (WSL), you can run `dfx` also on a Windows system as described below.
 
-## Installing WSL on Windows
+## Installing WSL
 
-Please follow the [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install) to  install WSL, make sure you’re running Windows 10 version 2004 and higher or Windows 11.
+Follow Microsoft's instructions for installing the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install). Make sure you are running Windows 10 (version 2004 or higher) or Windows 11.
 
-## WSL Supported Version
+### Supported WSL Versions
 
-Theoretically, WSL 1 and WSL 2 should be both fine to run `dfx`. But we highly recommend you to upgrade to WSL 2, please check the [Difference between WSL 1 and WSL 2](https://docs.microsoft.com/en-us/windows/wsl/compare-versions).
+Theoretically, WSL 1 and WSL 2 should both allow you to run `dfx`. However, we recommend WSL 2. [WSL Comparison](https://docs.microsoft.com/en-us/windows/wsl/compare-versions) explains the differences between WSL1 and WSL 2.
 
-### Check WSL version
+### Check your WSL version
 
-You can run the command `wsl –list –verbose (wsl -l -v)` to check the Linux distributions installed on your Windows. Below is an example of the result after running the command.
+Run the command `wsl –list –verbose (wsl -l -v)` to check the Linux distributions installed on your Windows machine. Below is an example output.
 
 ```
   NAME      STATE           VERSION
 * Ubuntu    Running         2
 ```
 
-To learn more about `wsl` command, please check the [Command reference for WSL](https://docs.microsoft.com/en-us/windows/wsl/basic-commands).
+To learn more about the `wsl` command, check the [command reference for WSL](https://docs.microsoft.com/en-us/windows/wsl/basic-commands).
 
 
 ### Upgrade to WSL 2
 
-If you have WSL 1 installed, please follow the [Upgrade instructions](https://docs.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2) to upgrade to WSL 2. Basically you need to: 
-
+If you have WSL 1 installed, follow the [upgrade instructions](https://docs.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2) to upgrade to WSL 2. Basically you need to: 
 * Install the [WSL 2 Linux kernel update package](https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-4---download-the-linux-kernel-update-package).
-
 * Run the following command to set your Linux distributions to version 2.  
   `wsl --set-version <distribution name> 2`
 
-## Running Linux Distributions
+## Running Linux
 
 After you have WSL installed, you can launch the Linux distributions by name.
 
@@ -39,12 +37,12 @@ For example `Ubuntu.exe` is the command to start the `Ubuntu` distribution from 
 
 ## Installing DFX
 
-Once you have WSL installed, please follow [Installing tools](hello10mins#1-installing-tools) to install `dfx`.
+Once you have WSL installed, you can install `dfx` within your WSL Linux terminal as described in [Installing the SDK](../build/install-upgrade-remove).
 
 ## Troubleshooting
 
 ### Node.js is not properly installed
-WSL 2 has node.js `10.x.x` installed by default. But the latest `dfx` requires node.js `16.0.0` or higher, please check [Node.js](hello10mins#12-nodejs) for more information.
+WSL 2 has node.js `10.x.x` installed by default. But the latest `dfx` requires node.js `16.0.0` or higher, please check [Node.js](hello10mins#nodejs) for more information.
 
 ### Permission Denied when running `dfx start`
-Projects created from `dfx` need to be on the Linux Filesystem instead of the Windows Filesystem. Usually `cd ~` or `cd $HOME` in the WSL terminal will bring you to the home directory, and creating projects in there should work.
+Projects created from `dfx` need to be on the Linux filesystem instead of the Windows filesystem. Usually `cd ~` or `cd $HOME` in the WSL terminal will bring you to the home directory, and creating projects in there should work.


### PR DESCRIPTION
@aisconnolly I finally made the OS changes we discussed last week. Could you please take a look. I recommend we move the WSL instructions under `Installing the SDK` so that the `Quick Start` remains clean and simple. May I ask you to do these file move acrobatics? 