### PR TITLE
Suspend CD to Netlify from GH actions

### DIFF
--- a/.github/workflows/cd--preview-netlify.yml
+++ b/.github/workflows/cd--preview-netlify.yml
@@ -1,32 +1,33 @@
-#name: Deployment Preview
+name: Deployment Preview
 
-#on:
-#  pull_request:
+on:
+  pull_request:
   
-#jobs:
-#  deployment:
-#    name: "Preview deployment"
-#    runs-on: ubuntu-latest
-#    
-#    environment: 
-#      name: "Preview Netlify"
-#      url: ${{ fromJson(steps.deploy.outputs.url) }}
-#    
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: Install Dependencies
-#        run: npm install
-#
-#      - name: Deploy Site
-#        id: deploy
-#        env:
-#          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-#          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-#          CONTEXT: deploy-preview
-#         NETLIFY: true
-#          PR_URL: ${{ github.event.pull_request.html_url }}
-#        run: |
-#          netlify deploy --dir=build --build --context deploy-preview | tee logs.txt
-#          PREVIEW_URL="$(cat logs.txt | grep "Website Draft URL" | awk -F'Website Draft URL: ' '{print $2}')"
-#          echo "::set-output name=url::\"$PREVIEW_URL\""
+jobs:
+  deployment:
+    if: ${{ false }} # Disabled, see https://github.com/dfinity/portal/pull/94
+    name: "Preview deployment"
+    runs-on: ubuntu-latest
+    
+    environment: 
+      name: "Preview Netlify"
+      url: ${{ fromJson(steps.deploy.outputs.url) }}
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Deploy Site
+        id: deploy
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          CONTEXT: deploy-preview
+          NETLIFY: true
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          netlify deploy --dir=build --build --context deploy-preview | tee logs.txt
+          PREVIEW_URL="$(cat logs.txt | grep "Website Draft URL" | awk -F'Website Draft URL: ' '{print $2}')"
+          echo "::set-output name=url::\"$PREVIEW_URL\""

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,28 +8,29 @@ on:
     branches: [master]
 
 jobs:
-  #deploy-netlify:
-  #  name: "Deploy to Netlify"
-  #  runs-on: ubuntu-latest
-  #
-  #  environment:
-  #    name: "Beta Netlify"
-  #    url: https://beta.smartcontracts.org
-  #
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #
-  #    - name: Install Dependencies
-  #      run: npm install
-  #
-  #    - name: Build site
-  #      run: npm run build
-  #
-  #    - name: Deploy Site
-  #      env:
-  #        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-  #        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-  #      run: netlify deploy --dir=build --prod
+  deploy-netlify:
+    if: ${{ false }} # Disabled, see https://github.com/dfinity/portal/pull/94
+    name: "Deploy to Netlify"
+    runs-on: ubuntu-latest
+
+    environment:
+      name: "Beta Netlify"
+      url: https://beta.smartcontracts.org
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build site
+        run: npm run build
+
+      - name: Deploy Site
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: netlify deploy --dir=build --prod
 
   deploy-ic:
     name: "Deploy to IC"


### PR DESCRIPTION
Netlify does not allow to set permissions on the tokens used for the preview deployments.
Thus I had to re-enable it from Netlify and temporarily suspend any CD operation to Netlify from GitHub actions.
This will make complicated the preview of references once we have the CI jobs to do so.