### PR TITLE
Add dfx start/replica options for bitcoin, canister http features

### DIFF
--- a/docs/references/cli-reference/dfx-replica.md
+++ b/docs/references/cli-reference/dfx-replica.md
@@ -18,20 +18,17 @@ You can use the following optional flags with the `dfx replica` command.
 |-------------------|-------------------------------|
 | `-h`, `--help`    | Displays usage information.   |
 | `-V`, `--version` | Displays version information. |
-
-| `--enable-bitcoin`| Enables bitcoin integration.    |
-
+| `--enable-bitcoin`| Enables bitcoin integration.  |
 | `--enable-canister-http` | Enables canister HTTP requests. |
 
 ## Options
 
 You can use the following option with the `dfx replica` command.
 
-| Option        | Description                                                                   |
-|---------------|-------------------------------------------------------------------------------|
-| `--port port` | Specifies the port the local canister execution environment should listen to. |
-
-| `--bitcoin-node <host:port>`         | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
+| Option                    | Description                                                                   |
+|---------------------------|-------------------------------------------------------------------------------|
+| `--port port`             | Specifies the port the local canister execution environment should listen to. |
+| `--bitcoin-node host:port` | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
 
 
 ## Examples

--- a/docs/references/cli-reference/dfx-replica.md
+++ b/docs/references/cli-reference/dfx-replica.md
@@ -19,6 +19,10 @@ You can use the following optional flags with the `dfx replica` command.
 | `-h`, `--help`    | Displays usage information.   |
 | `-V`, `--version` | Displays version information. |
 
+| `--enable-bitcoin`| Enables bitcoin integration.    |
+
+| `--enable-canister-http` | Enables canister HTTP requests. |
+
 ## Options
 
 You can use the following option with the `dfx replica` command.
@@ -26,6 +30,9 @@ You can use the following option with the `dfx replica` command.
 | Option        | Description                                                                   |
 |---------------|-------------------------------------------------------------------------------|
 | `--port port` | Specifies the port the local canister execution environment should listen to. |
+
+| `--bitcoin-node <host:port>`         | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
+
 
 ## Examples
 

--- a/docs/references/cli-reference/dfx-start.md
+++ b/docs/references/cli-reference/dfx-start.md
@@ -18,11 +18,8 @@ You can use the following optional flags with the `dfx start` command.
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--background`    | Starts the local canister execution environment and web server processes in the background and waits for a reply before returning to the shell.                                                                                              |
 | `--clean`         | Starts the local canister execution environment and web server processes in a clean state by removing checkpoints from your project cache. You can use this flag to set your project cache to a new state when troubleshooting or debugging. |
-
 | `--enable-bitcoin` | Enables bitcoin integration. |
-
 | `--enable-canister-http`         | Enables canister HTTP requests. |
-
 | `-h`, `--help`    | Displays usage information.                                                                                                                                                                                                                  |
 | `-V`, `--version` | Displays version information.                                                                                                                                                                                                                |
 
@@ -33,8 +30,7 @@ You can use the following option with the `dfx start` command.
 | Option        | Description                                                                                                       |
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default is `127.0.0.1:8000`. |
-
-| `--bitcoin-node <host:port>`         | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
+| `--bitcoin-node host:port`         | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
 
 ## Examples
 

--- a/docs/references/cli-reference/dfx-start.md
+++ b/docs/references/cli-reference/dfx-start.md
@@ -18,6 +18,11 @@ You can use the following optional flags with the `dfx start` command.
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--background`    | Starts the local canister execution environment and web server processes in the background and waits for a reply before returning to the shell.                                                                                              |
 | `--clean`         | Starts the local canister execution environment and web server processes in a clean state by removing checkpoints from your project cache. You can use this flag to set your project cache to a new state when troubleshooting or debugging. |
+
+| `--enable-bitcoin` | Enables bitcoin integration. |
+
+| `--enable-canister-http`         | Enables canister HTTP requests. |
+
 | `-h`, `--help`    | Displays usage information.                                                                                                                                                                                                                  |
 | `-V`, `--version` | Displays version information.                                                                                                                                                                                                                |
 
@@ -28,6 +33,8 @@ You can use the following option with the `dfx start` command.
 | Option        | Description                                                                                                       |
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default is `127.0.0.1:8000`. |
+
+| `--bitcoin-node <host:port>`         | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
 
 ## Examples
 


### PR DESCRIPTION
Document new dfx command-line options for bitcoin integration and http requests.

See:
- https://github.com/dfinity/sdk/pull/2165
- https://github.com/dfinity/sdk/pull/2173

---
Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [x] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [x] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
