### PR TITLE
add explanation on what the did file is

### DIFF
--- a/docs/developer-docs/build/languages/candid/candid-howto.md
+++ b/docs/developer-docs/build/languages/candid/candid-howto.md
@@ -12,6 +12,14 @@ service Counter : {
 
 Now, let’s explore how to interact with this canister in different scenarios with the help of Candid.
 
+# The .did file
+
+Candid types can be used to describe a service via a Candid service description file (.`.did` file), which can either be manually written or generated from a service implementation. 
+
+If you write a canister in Motoko, for example, the compiler automatically generates a Candid description when you compile the program. If you use the SDK, You will typically see the auto-generated `.did` files in the `/declarations` directory of your project. Since these files are are auto-generated, it is recommended they should not be manually edited. Even if you change the `.did` files in your project, they will be overwritten in the next dfx build.
+
+In other languages, like Rust, you will have to write the Candid interface description manually. With the help of types, we developed tools to automatically generate UI and perform random testing based on the service description file. 
+
 ## Interact with a service in a terminal
 
 One of the most common ways you interact with canisters and the IC is by using the {company-id} Canister SDK `dfx` command-line interface.

--- a/docs/developer-docs/build/languages/candid/candid-howto.md
+++ b/docs/developer-docs/build/languages/candid/candid-howto.md
@@ -14,7 +14,7 @@ Now, let’s explore how to interact with this canister in different scenarios w
 
 # The .did file
 
-Candid types can be used to describe a service via a Candid service description file (.`.did` file), which can either be manually written or generated from a service implementation. 
+Candid types can be used to describe a service via a Candid service description file (`.did` file), which can either be manually written or generated from a service implementation. 
 
 If you write a canister in Motoko, for example, the compiler automatically generates a Candid description when you compile the program. If you use the SDK, You will typically see the auto-generated `.did` files in the `/declarations` directory of your project. Since these files are are auto-generated, it is recommended they should not be manually edited. Even if you change the `.did` files in your project, they will be overwritten in the next dfx build.
 

--- a/docs/developer-docs/build/languages/candid/candid-howto.md
+++ b/docs/developer-docs/build/languages/candid/candid-howto.md
@@ -16,7 +16,7 @@ Now, let’s explore how to interact with this canister in different scenarios w
 
 Candid types can be used to describe a service via a Candid service description file (`.did` file), which can either be manually written or generated from a service implementation. 
 
-If you write a canister in Motoko, for example, the compiler automatically generates a Candid description when you compile the program. If you use the SDK, You will typically see the auto-generated `.did` files in the `/declarations` directory of your project. Since these files are are auto-generated, it is recommended they should not be manually edited. Even if you change the `.did` files in your project, they will be overwritten in the next dfx build.
+If you write a canister in Motoko, for example, the compiler automatically generates a Candid description when you compile the program. If you use the SDK, you will typically see the auto-generated `.did` files in the `/declarations` directory of your project. Since these files are are auto-generated, it is recommended they should not be manually edited. Even if you change the `.did` files in your project, they will be overwritten in the next dfx build.
 
 In other languages, like Rust, you will have to write the Candid interface description manually. With the help of types, we developed tools to automatically generate UI and perform random testing based on the service description file. 
 


### PR DESCRIPTION
This adds explanation to what the `.did` file is: https://dfinity.atlassian.net/browse/DD-9