### PR TITLE
fix unclickable link on /basics page

### DIFF
--- a/src/components/Basics/TrueScaling/index.module.css
+++ b/src/components/Basics/TrueScaling/index.module.css
@@ -41,6 +41,7 @@
   top: calc(50% + 0px);
   left: calc(50% + 650px);
   transform: translate(-50%, -50%);
+  pointer-events: none;
 }
 
 .statusCard {


### PR DESCRIPTION
This link is being overlapped by the large background image under it, and most of it is not clickable.
<img width="628" alt="image" src="https://user-images.githubusercontent.com/9403182/177290041-9955ad35-1d0e-4ca0-9c16-459366332843.png">
