### PR TITLE
remove references to dfinity.org/showcase; fix node provider link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
         path: "samples",
         routeBasePath: "samples",
         sidebarPath: require.resolve("./sidebarsSample.js"),
-        remarkPlugins: [require('remark-code-import')],
+        remarkPlugins: [require("remark-code-import")],
       },
     ],
     customDocusaurusPlugin,
@@ -72,7 +72,7 @@ const config = {
           },
 
           sidebarPath: require.resolve("./sidebars.js"),
-          remarkPlugins: [simplePlantUML, require('remark-code-import')],
+          remarkPlugins: [simplePlantUML, require("remark-code-import")],
           // TODO: Please change this to your repo.
           editUrl: "https://github.com/dfinity/portal/edit/master/",
         },
@@ -137,10 +137,10 @@ const config = {
                 label: "Internet Identity",
                 href: "https://identity.ic0.app/",
               },
-              {
-                label: "Showcase",
-                href: "https://dfinity.org/showcase",
-              },
+              // {
+              //   label: "Showcase",
+              //   href: "/showcase",
+              // },
               {
                 label: "Dashboard",
                 href: "https://dashboard.internetcomputer.org",

--- a/src/components/Basics/Ecosystem/index.tsx
+++ b/src/components/Basics/Ecosystem/index.tsx
@@ -67,7 +67,7 @@ const Ecosystem = () => {
             The reverse gas model enables free-to-use, truly user-friendly
             dapps, ready for mass adoption.
           </p>
-          <Link href="https://dfinity.org/showcase" className="cta-link">
+          <Link href="/#showcase" className="cta-link">
             <svg
               width="24"
               viewBox="0 0 24 24"

--- a/src/components/Basics/Ecosystem2/index.tsx
+++ b/src/components/Basics/Ecosystem2/index.tsx
@@ -37,11 +37,7 @@ const categories = [
     ),
     image: require("../../../../static/img/basics/export-nft.png").default,
     link: (
-      <a
-        href="https://dfinity.org/showcase?tag=nft"
-        target={"_blank"}
-        className={styles.link}
-      >
+      <a href="/showcase?tag=nft" target={"_blank"} className={styles.link}>
         Explore more NFT projects <OutgoingLink></OutgoingLink>
       </a>
     ),
@@ -64,11 +60,7 @@ const categories = [
     ),
     image: require("../../../../static/img/basics/export-social.png").default,
     link: (
-      <a
-        href="https://dfinity.org/showcase?tag=nft"
-        target={"_blank"}
-        className={styles.link}
-      >
+      <a href="/showcase?tag=nft" target={"_blank"} className={styles.link}>
         Explore more SocialFi projects <OutgoingLink></OutgoingLink>
       </a>
     ),
@@ -91,11 +83,7 @@ const categories = [
     ),
     image: require("../../../../static/img/basics/export-defi.png").default,
     link: (
-      <a
-        href="https://dfinity.org/showcase?tag=nft"
-        target={"_blank"}
-        className={styles.link}
-      >
+      <a href="/showcase?tag=nft" target={"_blank"} className={styles.link}>
         Explore more DeFi projects <OutgoingLink></OutgoingLink>
       </a>
     ),
@@ -119,11 +107,7 @@ const categories = [
     image: require("../../../../static/img/basics/export-metaverse.png")
       .default,
     link: (
-      <a
-        href="https://dfinity.org/showcase?tag=nft"
-        target={"_blank"}
-        className={styles.link}
-      >
+      <a href="/showcase?tag=nft" target={"_blank"} className={styles.link}>
         Explore more Metaverse projects <OutgoingLink></OutgoingLink>
       </a>
     ),
@@ -164,7 +148,7 @@ const Ecosystem2 = () => {
           className={styles.headingContainer}
         >
           <h2 className="heading-2">Ecosystem</h2>
-          <Link href="https://dfinity.org/showcase" className="cta-link">
+          <Link href="/#showcase" className="cta-link">
             Go to Ecosystem showcase
             <svg
               width="24"
@@ -211,7 +195,7 @@ const Ecosystem2 = () => {
                 style={{ opacity: category === selectedCategory ? 1 : 0 }}
               />
             ))}
-            {selectedCategory.link}
+            {/* {selectedCategory.link} */}
             {selectedCategory.credit}
           </motion.div>
         </div>
@@ -223,7 +207,7 @@ const Ecosystem2 = () => {
             <div key={index} className={styles.mobileCategoryCard}>
               <h3>{category.title}</h3>
               <img src={category.image} alt="" />
-              {category.link}
+              {/* {category.link} */}
             </div>
           ))}
         </motion.div>

--- a/src/components/Basics/TrueScaling/index.tsx
+++ b/src/components/Basics/TrueScaling/index.tsx
@@ -54,7 +54,10 @@ const TrueScaling = () => {
           By adding new subnets regularly, the IC scales to an unbounded number
           of dapps and allows storage of unlimited data.
         </p>
-        <Link href="https://dfinity.org/showcase" className="cta-link">
+        <Link
+          href="https://internet-computer.typeform.com/to/IWl3iClx"
+          className="cta-link"
+        >
           <svg
             width="24"
             viewBox="0 0 24 24"

--- a/src/components/LandingPage/HeroSection/index.tsx
+++ b/src/components/LandingPage/HeroSection/index.tsx
@@ -36,10 +36,7 @@ function Index() {
           <Link className={styles.actionButton} to="/developers">
             BUILD REAL WEB3
           </Link>
-          <Link
-            className={styles.callToAction}
-            to={"https://dfinity.org/showcase/"}
-          >
+          <Link className={styles.callToAction} to={"#showcase"}>
             Explore the Internet Computer
           </Link>
         </motion.div>

--- a/src/components/LandingPage/Showcase/index.tsx
+++ b/src/components/LandingPage/Showcase/index.tsx
@@ -260,13 +260,13 @@ function Showcase() {
                 developer and entrepreneurial activity. Get inspired by the
                 existing dapps.
               </p>
-              <Link
+              {/* <Link
                 className={styles.callToAction}
-                to={"https://dfinity.org/showcase/"}
+                to={"???"}
               >
                 <RightPointer />
                 <p> Explore the Internet Computer ecosystem</p>
-              </Link>
+              </Link> */}
             </motion.div>
           </div>
           <motion.div


### PR DESCRIPTION
This is in preparation for removing the /showcase page from dfinity.org and migrating it to internetcomputer.org over the next week. Temporarily the most extensive showcase will be the internetcomputer.org/#showcase section.

Also fixed the "Become a node provider" link to go to https://internet-computer.typeform.com/to/IWl3iClx

Changed all showcase page links to https://internetcomputer.org/#

Removed the Showcase item from the main nav 
![image](https://user-images.githubusercontent.com/9403182/177991952-87dcd9c2-30c5-43f0-8b55-3e8284249d04.png)

Removed the button to go to the showcase from the right side image
![image](https://user-images.githubusercontent.com/9403182/177992082-8c26c0e4-cc41-4e78-9d4d-304eba617380.png)

The link now goes to the Typeform found on the ICA website
![image](https://user-images.githubusercontent.com/9403182/177992283-0be9cee6-eb25-4b15-bcbe-84dd83594cbe.png)

Removed the showcase page link on the home page showcase section:
![image](https://user-images.githubusercontent.com/9403182/177992759-b0dd40ce-3eb8-40a8-b625-ef6a1efad68b.png)


