### PR TITLE
Update ledger-local-setup.md

### DIFF
--- a/docs/developer-docs/functionality/ledger/ledger-local-setup.md
+++ b/docs/developer-docs/functionality/ledger/ledger-local-setup.md
@@ -33,7 +33,8 @@ Follow the steps below to deploy your copy of the ledger canister to a local rep
         "ledger": {
           "type": "custom",
           "wasm": "ledger.wasm",
-          "candid": "ledger.private.did"
+          "candid": "ledger.private.did",
+          "build": []
         }
       }
     }


### PR DESCRIPTION
A custom canister type that uses a .wasm file, according to docs we might not need a build field. But in this case, we'll see an error like this:

Error: Failed to read config from current working directory.
Caused by: Failed to read config from current working directory.
    Failed to read config from directory /Users/me/dev/dfinity/examples/rust/basic_bitcoin.
Failed to load config from /Users/me/dev/dfinity/examples/rust/basic_bitcoin/dfx.json.
  missing field `build` at line 17 column 5

dfx 0.11.1 will make the build field optional again. to fix this, we can add "build": [] to our custom canister definition in dfx.json file.

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
