### PR TITLE
bugfix: scrolled down page was too wide on mobile

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -239,7 +239,6 @@ div[class^="announcementBarContent"] {
 .navbar-sidebar {
   --ifm-navbar-sidebar-width: 100vw;
   --ifm-navbar-background-color: white;
-  transform: translate3d(100%, 0, 0);
 }
 
 /* larger mobile menu items */


### PR DESCRIPTION
how to reproduce:
1. open any page on a mobile device / sub 996px width browser window
2. scroll down so that the header disappears
3. now you can scroll to the right and there's empty space there

this seems to be caused by an extra css rule that doesn't seem to serve any purpose, probably added by mistake