### PR TITLE
remove 'trustless' in core protocol roadmap intro

### DIFF
--- a/roadmap/1_core-protocol/index.md
+++ b/roadmap/1_core-protocol/index.md
@@ -4,5 +4,5 @@ title: Core Protocol
 card: /img/roadmap/core-protocol.card.jpg
 overlay: /img/roadmap/core-protocol.overlay.jpg
 ---
-Roughly 43 percent of the technical contributions from the R&D team at the DFINITY Foundation revolve around making the Internet Computer protocol efficient, scalable, trustless and interoperable with other blockchains. The core protocol involves all things replica, including the system, the networking layer, consensus, the execution environment and crypto libraries. 
+Roughly 43 percent of the technical contributions from the R&D team at the DFINITY Foundation revolve around making the Internet Computer protocol verifiably decentralized, efficient, scalable, and interoperable with other blockchains. The core protocol involves all things replica, including the system, the networking layer, consensus, the execution environment and crypto libraries. 
   


### PR DESCRIPTION
Minor text modification in roadmap to avoid a confusion pointed out on the forum