### PR TITLE
display search in progress indicator

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -16,6 +16,8 @@ const Search = (props) => {
   const initialized = useRef(false);
   const searchBarRef = useRef(null);
   const [indexReady, setIndexReady] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const searchHandle = useRef(null);
   const history = useHistory();
   const { siteConfig = {} } = useDocusaurusContext();
   const { baseUrl } = siteConfig;
@@ -48,6 +50,22 @@ const Search = (props) => {
 
         history.push(url);
       },
+      beginSearch: () => {
+        if (searchHandle.current) {
+          clearTimeout(searchHandle.current);
+        }
+        searchHandle.current = setTimeout(() => {
+          setSearching(true);
+          searchHandle.current = null;
+        }, 300);
+      },
+      endSearch: () => {
+        setSearching(false);
+        if (searchHandle.current) {
+          clearTimeout(searchHandle.current);
+          searchHandle.current = null;
+        }
+      },
     });
   };
 
@@ -58,6 +76,11 @@ const Search = (props) => {
       setIndexReady(true);
       initialized.current = true;
     })();
+    return () => {
+      if (searchHandle.current) {
+        clearTimeout(searchHandle.current);
+      }
+    };
   }, []);
 
   const toggleSearchIconClick = useCallback(
@@ -101,6 +124,11 @@ const Search = (props) => {
         ref={searchBarRef}
         disabled={!indexReady}
       />
+      <span
+        className={classnames("navbar__search-indicator", {
+          "navbar__search-indicator--searching": searching,
+        })}
+      ></span>
     </div>
   );
 };

--- a/src/theme/SearchBar/lib/DocSearch.js
+++ b/src/theme/SearchBar/lib/DocSearch.js
@@ -26,6 +26,8 @@ class DocSearch {
     transformData = false,
     queryHook = false,
     handleSelected = false,
+    beginSearch = false,
+    endSearch = false,
     enhancedSearchInput = false,
     layout = "collumns",
   }) {
@@ -70,7 +72,8 @@ class DocSearch {
 
     const customHandleSelected = handleSelected;
     this.handleSelected = customHandleSelected || this.handleSelected;
-
+    this.beginSearch = beginSearch;
+    this.endSearch = endSearch;
     // We prevent default link clicking if a custom handleSelected is defined
     if (customHandleSelected) {
       $(".algolia-autocomplete").on("click", ".ds-suggestions a", (event) => {
@@ -144,18 +147,24 @@ class DocSearch {
         // eslint-disable-next-line no-param-reassign
         query = queryHook(query) || query;
       }
-      this.client.search(query).then((hits) => {
-        if (
-          this.queryDataCallback &&
-          typeof this.queryDataCallback == "function"
-        ) {
-          this.queryDataCallback(hits);
-        }
-        if (transformData) {
-          hits = transformData(hits) || hits;
-        }
-        callback(DocSearch.formatHits(hits));
-      });
+      if (this.beginSearch) this.beginSearch();
+      this.client
+        .search(query)
+        .then((hits) => {
+          if (
+            this.queryDataCallback &&
+            typeof this.queryDataCallback == "function"
+          ) {
+            this.queryDataCallback(hits);
+          }
+          if (transformData) {
+            hits = transformData(hits) || hits;
+          }
+          callback(DocSearch.formatHits(hits));
+        })
+        .finally(() => {
+          if (this.endSearch) this.endSearch();
+        });
     };
   }
 

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -30,3 +30,41 @@
     --ifm-navbar-search-input-background-color: white;
   }
 }
+.navbar__search-input {
+  background: var(--ifm-navbar-search-input-background-color);
+}
+.navbar__search {
+  position: relative;
+}
+.navbar__search-indicator {
+  background: var(--ifm-navbar-search-input-icon) no-repeat 0.75rem center /
+    1rem 1rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 32px;
+}
+.navbar__search-indicator--searching {
+  background: none;
+}
+.navbar__search-indicator--searching:after {
+  content: " ";
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 14px 11px;
+  border-radius: 50%;
+  border: 2px solid #181818;
+  border-color: #181818 transparent #181818 transparent;
+  animation: lds-dual-ring 1.2s linear infinite;
+}
+
+@keyframes lds-dual-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
The search API function is running on a serverless endpoint. Infrequent usage (ie. more than a few minutes between searches) will lead to cold starts, making the first search call respond only after 1-2 seconds. 

This PR adds an "in progress" indicator whenever search takes longer than 300ms.

![image](https://user-images.githubusercontent.com/9403182/193809104-40abdc5b-95f0-45a7-bdb4-6771a683617a.png)

