### PR TITLE
Add ETA to DTS on the public roadmap

### DIFF
--- a/roadmap/1_core-protocol/in-progress/5_deterministic-time-slicing.md
+++ b/roadmap/1_core-protocol/in-progress/5_deterministic-time-slicing.md
@@ -3,7 +3,7 @@ title: Deterministic Time Slicing
 links:
   Forum Link: https://forum.dfinity.org/t/deterministic-time-slicing/10635
   Proposal:
-eta:
+eta: November 2022
 is_community: false
 ---
 


### PR DESCRIPTION
Update the public roadmap to reflect that DTS will have an ETA of November 2022. 