### PR TITLE
Hide IC icon from the menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -330,13 +330,13 @@ const config = {
             label: "Sample Code",
           },
 
-          {
-            html: '<img src="/img/svgIcons/ic0.svg" alt="Go to version hosted on the Internet Computer"/> <span>Switch to ic0</span>',
-            position: "right",
+          // {
+          //   html: '<img src="/img/svgIcons/ic0.svg" alt="Go to version hosted on the Internet Computer"/> <span>Switch to ic0</span>',
+          //   position: "right",
 
-            href: `https://${require("./canister_ids.json").portal.ic}.ic0.app`,
-            className: "ic0-item",
-          },
+          //   href: `https://${require("./canister_ids.json").portal.ic}.ic0.app`,
+          //   className: "ic0-item",
+          // },
         ],
       },
 


### PR DESCRIPTION
We don't need this now 

<img width="508" alt="image" src="https://user-images.githubusercontent.com/105195369/203554409-4ed33a1a-884c-480f-ade9-bbd1a3139ff0.png">