### PR TITLE
Add idl2json to the ist of tools

### DIFF
--- a/src/components/Common/toolingItems.ts
+++ b/src/components/Common/toolingItems.ts
@@ -70,6 +70,13 @@ export const dfinityToolingItems = [
     links: { github: "https://github.com/dfinity/ic-js" },
   },
   {
+    title: "idl2json",
+    tags: ["development", "CLI"],
+    description:
+      "Command line tool for converting IDL/Candid to JSON",
+    links: { github: "https://github.com/dfinity/idl2json" },
+  },
+  {
     title: "Vessel Package Manager",
     tags: ["development", "CLI"],
     description:


### PR DESCRIPTION
# Motivation
There is a request to add idl2json to this list of tools: https://github.com/dfinity/idl2json/issues/9

# Changes
Added `idl2json` to the list of tools.

# Required
- [x] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [x] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
