### PR TITLE
fix ICP price plugin

### DIFF
--- a/plugins/icp-price.js
+++ b/plugins/icp-price.js
@@ -6,12 +6,10 @@ const icpPricePlugin = async function (context, options) {
     name: "icp-price",
     async loadContent() {
       const ticker = await fetch(
-        "https://api.binance.com/api/v3/ticker/24hr?symbol=ICPUSDT"
+        "https://api.coinbase.com/v2/prices/ICP-USD/buy"
       ).then((res) => res.json());
 
-      console.log(JSON.stringify(ticker, null, 2));
-
-      return +ticker.lastPrice;
+      return +ticker.data.amount;
     },
     async contentLoaded({ content, actions }) {
       const { setGlobalData } = actions;

--- a/plugins/icp-price.js
+++ b/plugins/icp-price.js
@@ -9,6 +9,8 @@ const icpPricePlugin = async function (context, options) {
         "https://api.binance.com/api/v3/ticker/24hr?symbol=ICPUSDT"
       ).then((res) => res.json());
 
+      console.log(JSON.stringify(ticker, null, 2));
+
       return +ticker.lastPrice;
     },
     async contentLoaded({ content, actions }) {


### PR DESCRIPTION
Formerly queried from Binance, after migrating to IC hosting this price query has been sent from github actions. Binance seems to have the IP's of workers banned, so the price query has been silently failing. This PR switches to the coinbase API.