### PR TITLE
Security Best Practices: Remove wording that canister best practices focus only on Rust

### DIFF
--- a/docs/references/security/index.md
+++ b/docs/references/security/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This document provides security best practices for developing Rust canisters and web apps served by canisters on the Internet Computer. These best practices are mostly inspired by issues found in security reviews.
+This document provides security best practices for developing canisters and web apps served by canisters on the Internet Computer. These best practices are mostly inspired by issues found in security reviews.
 
 We would like to advertise these best practices to developers so that potential issues can be addressed early during the development of new dapps, and not only in the end when (if at all) a security review is done. Ideally, this will make the development of secure dapps more efficient.
 
@@ -14,7 +14,7 @@ We provide the following security best practices in the subsequent pages:
 
 -   [Web App Specific Security Best Practices](./web-app-development-security-best-practices.md),
 
--   [Rust Canister Development Security Best Practices](./rust-canister-development-security-best-practices.md)
+-   [Canister Development Security Best Practices](./rust-canister-development-security-best-practices.md)
 
 ## Target Audience
 
@@ -23,5 +23,3 @@ This document was initially intended for internal use at DFINITY. However, we no
 ## Disclaimers and Limitations
 
 We provide a collection of best practices that may grow over time. While we think this is useful to improve security of dapps on the Internet Computer, we’d like to point out that such a list will never be complete and will never cover all potential security concerns. For example, there will always be attack vectors very specific to a dapps use cases that cannot be covered by general best practices. Thus, following the best practices can complement, but not replace security reviews. Especially for security critical dapps we recommend performing security reviews/audits. Furthermore, please not that the best practices are currently not ordered according to risk or priority.
-
-Currently, the canister best practices focus on Rust. We will work towards including best practices specific to Motoko as well.

--- a/docs/references/security/rust-canister-development-security-best-practices.md
+++ b/docs/references/security/rust-canister-development-security-best-practices.md
@@ -1,4 +1,4 @@
-# Rust Canister Development Security Best Practices
+# Canister Development Security Best Practices
 
 ## Smart Contracts Canister Control
 
@@ -59,11 +59,11 @@ If this is not the case, an attacker may be able to perform sensitive actions on
 
 #### Security Concern
 
-`ic0::api::caller` may also return `Principal::anonymous()`. In authenticated calls, this is probably undesired (and could have security implications) since this would behave like a shared account for anyone that does unauthenticated calls.
+The caller from the system API (e.g. `ic0::api::caller` in Rust) may also return `Principal::anonymous()`. In authenticated calls, this is probably undesired (and could have security implications) since this would behave like a shared account for anyone that does unauthenticated calls.
 
 #### Recommendation
 
-In authenticated calls, make sure the caller is not anonymous and return an error or trap if it is. This could e.g. be done centrally by using a helper method such as:
+In authenticated calls, make sure the caller is not anonymous and return an error or trap if it is. This could e.g. be done centrally by using a helper method. In Rust it could e.g. look as follows:
 
     fn caller() -> Result<Principal, String> {
         let caller = ic0::api::caller();
@@ -97,7 +97,7 @@ If an app is served through `raw.ic0.app` in addition to `ic0.app`, an adversary
 
 ## Canister Storage
 
-### Use `thread_local!` with `Cell/RefCell` for state variables and put all your globals in one basket.
+### Rust: Use `thread_local!` with `Cell/RefCell` for state variables and put all your globals in one basket.
 
 #### Security Concern
 


### PR DESCRIPTION
Remove wording that canister best practices focus only on Rust. This is because from now on, there will be best practices for both Rust and Motoko. 