### PR TITLE
Updating information about Bitcoin integration pricing

### DIFF
--- a/docs/developer-docs/deploy/computation-and-storage-costs.md
+++ b/docs/developer-docs/deploy/computation-and-storage-costs.md
@@ -48,8 +48,8 @@ A thorough example how the cost of running a canister on a 13-node app subnet is
 
 **Notes:**
 * System API calls are just like normal function calls from the WebAssembly stand point. The number of instructions each call takes depends on the work done.
-* Bitcoin testnet prices remain currently as is to not break existing canisters, and thus are an exception to the linear scaling of pricing.
-* The Bitcoin feature for Bitcoin Mainnet is launched initially on a subnet with slightly less than 34 nodes that will be grown over time, but the 34-node price as advertised above is charged to avoid frequent price changes. *The Bitcoin API on high-replication subnets requires to send more cycles as specified for future-proofness.* Bitcoin pricing charges the actually required Wasm instructions of the Bitcoin canister to achieve fair charging. See the [Bitcoin documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works) for further details regarding the specifics of Bitcoin pricing.
+* The Bitcoin canister for Bitcoin mainnet is launched initially on a 13-node subnet but the 34-node price as advertised above is charged to avoid frequent price changes. *The Bitcoin API on high-replication subnets requires to send more cycles as specified for future-proofness.* Bitcoin pricing charges the actually required Wasm instructions of the Bitcoin canister to achieve fair charging. See the [Bitcoin documentation](https://internetcomputer.org/docs/current/developer-docs/integrations/bitcoin/bitcoin-how-it-works) for further details regarding the specifics of Bitcoin pricing.
+* Prices for Bitcoin testnet are 40% of the prices for Bitcoin mainnet.
 
 The USD cost for transactions below is based on the above cycle costs. 1 XDR is equal to 1 Trillion cycles. As of November 23, 2022, the exchange rate for 1 XDR = $1.308860, which is used on this page. The exchange rate for USD/XDR may vary and it will impact the conversion rate. For XDR exchange rates please visit: <https://www.imf.org/external/np/fin/data/rms_sdrv.aspx>
 


### PR DESCRIPTION
The Bitcoin integration pricing information is slightly outdated, in particular for Bitcoin testnet.
This PR fixes this by stating the formula to get to the prices for Bitcoin testnet.