### PR TITLE
Rename chain-key transactions to chain-key signing

### DIFF
--- a/how-it-works/2_chainkeytech/02_threshold-ecdsa-signing.card.md
+++ b/how-it-works/2_chainkeytech/02_threshold-ecdsa-signing.card.md
@@ -1,5 +1,5 @@
 ---
-title: Chain-key transactions
+title: Chain-key signing
 abstract: This feature will enable canister smart contracts to sign with regard to an ECDSA public key while their host subnet has a threshold shared secret key.
 coverImage: /img/how-it-works/threshold-ecdsa-signing.600x300.jpg
 ---
@@ -8,8 +8,8 @@ coverImage: /img/how-it-works/threshold-ecdsa-signing.600x300.jpg
 
 # Chain-key transactions
 
-*Chain-key transactions* extends chain-key technology to allow transactions targeted at other blockchains to be computed fully on-chain using the Internet Computer Protocol.
-Using chain-key transactions, the IC can integrate with other blockchains such as Bitcoin and Ethereum in a completely trustless manner without needing any bridges. Canisters can now securely store and transact Bitcoin. The secret key of the Bitcoin is shared between all the nodes running the canister. The canister can trasact Bitcoin (using a chain-key transaction) only when at least 2/3rd of the nodes agree to make the transaction. Indeed, using chain-key transactions is the strongest, most decentralized way of integrating blockchains as no additional trust assumptions besides that of the two blockchains are required, particularly no additional parties that manage signature keys or their shares. 
+*Chain-key signing* extends chain-key technology to allow transactions targeted at other blockchains to be computed fully on-chain using the Internet Computer Protocol.
+Using chain-key signing, the IC can integrate with other blockchains such as Bitcoin and Ethereum in a completely trustless manner without needing any bridges. Canisters can now securely store and transact Bitcoin. The secret key of the Bitcoin is shared between all the nodes running the canister. The canister can trasact Bitcoin using a chain-key signed transaction only when at least 2/3rd of the nodes agree to make the transaction. Indeed, using chain-key signing is the strongest, most decentralized way of integrating blockchains as no additional trust assumptions besides that of the two blockchains are required, particularly no additional parties that manage signature keys or their shares. 
 
 [Go deeper](/how-it-works/threshold-ecdsa-signing/)
 

--- a/how-it-works/2_chainkeytech/02_threshold-ecdsa-signing.subpage.md
+++ b/how-it-works/2_chainkeytech/02_threshold-ecdsa-signing.subpage.md
@@ -1,5 +1,5 @@
 ---
-title: Chain-Key Transactions
+title: Chain-key signing
 abstract: 
 shareImage: /img/how-it-works/threshold-ecdsa-signing.600.jpg
 slug: threshold-ecdsa-signing
@@ -7,11 +7,11 @@ slug: threshold-ecdsa-signing
 
 # Chain-Key Transactions
 
-*Chain-key transactions* extends chain-key technology to allow transactions targeted at other blockchains to be computed fully on-chain using the Internet Computer Protocol.
-Using chain-key transactions, the IC can integrate with other blockchains in a completely trustless manner.
-Indeed, using chain-key transactions is the strongest, most decentralized way of integrating blockchains as no additional trust assumptions besides that of the two blockchains are required, particularly no additional parties that manage signature keys or their shares.
+*Chain-key signing* extends chain-key technology to allow transactions targeted at other blockchains to be computed fully on-chain using the Internet Computer Protocol.
+Using chain-key signing, the IC can integrate with other blockchains in a completely trustless manner.
+Indeed, using chain-key signing is the strongest, most decentralized way of integrating blockchains as no additional trust assumptions besides that of the two blockchains are required, particularly no additional parties that manage signature keys or their shares.
 
-Just like chain-key technology, a key component of chain-key transactions is threshold signatures.
+Just like chain-key technology, a key component of chain-key signing is threshold signatures.
 For the reasons outlined [here](/how-it-works/chain-key-technology/), the threshold signature scheme used to implement chain-key cryptography is based on BLS signatures. While BLS signatures have distinct advantages, they are simply not compatible with other blockchains.
 In order to work with other blockchains, the IC must use threshold signatures that are compatible with the digital signature schemes of those other blockchains.
 By far, the most commonly used signature scheme used on other blockchains (including Bitcoin and Ethereum) is the [ECDSA signature scheme](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm).


### PR DESCRIPTION
This is to get the documentation in line with the terminology used by Dom more recently.