### PR TITLE
Fix canister name in hello10mins.md

### DIFF
--- a/docs/developer-docs/quickstart/hello10mins.md
+++ b/docs/developer-docs/quickstart/hello10mins.md
@@ -503,7 +503,7 @@ Note the way the message is constructed:
 
 -   `dfx canister --network ic call` is the setup for calling a canister on the IC.
 
--   `hello_backend greet` means we are sending a message to a canister named `hello` and evoking its `greet` method. `dfx` knows which `hello` canister (out of the many in the IC), one refers to because a mapping of `hello` to a canister id is stored locally in `.dfx/local/canister_ids.json`.
+-   `hello_backend greet` means we are sending a message to a canister named `hello_backend` and evoking its `greet` method. `dfx` knows which `hello_backend` canister (out of the many in the IC), one refers to because a mapping of `hello_backend` to a canister id is stored locally in `.dfx/local/canister_ids.json`.
 
 -   `'("everyone": text)'` is the parameter we are sending to `greet` (which accepts `Text` as its only input).
 


### PR DESCRIPTION
Change `hello` to `hello_backend` in the description of testing the on-chain dapp via the command line.

Sorry, I'm new here and don't know what the things below mean:

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
