### PR TITLE
Add redirects for previous Motoko documentation URLs

### DIFF
--- a/plugins/utils/redirects.js
+++ b/plugins/utils/redirects.js
@@ -8,6 +8,8 @@ const redirects = `
   /docs/candid-guide/candid-intro /docs/current/developer-docs/backend/candid/
   /docs/candid-guide/candid-ref /docs/current/references/candid-ref
   /docs/candid-guide/candid-types /docs/current/references/candid-ref  
+  /docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/ /docs/current/motoko/main/motoko-introduction
+  /docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/* /docs/current/motoko/main/:splat
   /docs/current/developer-docs/build/languages/candid/* /docs/current/developer-docs/backend/candid/:splat
   /docs/current/developer-docs/build/languages/motoko/ /docs/current/motoko/main/motoko-introduction
   /docs/current/developer-docs/build/languages/motoko/* /docs/current/motoko/main/:splat


### PR DESCRIPTION
This PR redirects from the previous Motoko documentation as a quick-fix for broken links in npm packages (e.g. [prettier-plugin-motoko](https://www.npmjs.com/package/prettier-plugin-motoko)) and [various Medium articles](https://medium.com/gitconnected/embed-motoko-interactive-smart-contracts-in-your-medium-story-or-blog-post-58c85719eee6). 

CC @dfx-json