### PR TITLE
Security Best Practices: Fix regression that restricts canister best practices to rust

### DIFF
--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.md
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.md
@@ -1,8 +1,10 @@
 ---
 sidebar_position: 2
-sidebar_label: "Canister development in Rust"
+sidebar_label: "Canister development"
 ---
-# Canister development in Rust security best practices
+# Canister development security best practices
+
+This document contains canister development best practices for both Motoko and Rust. 
 
 ## Smart Contracts Canister Control
 


### PR DESCRIPTION
Unfortunately during some restructuring, the title of the canister security best practices was reverted to restricting them to Rust only. But in fact these best practices are for both canister development in Motoko AND in Rust. 

This PR fixes the regression. 