### PR TITLE
Add product-security as CODEOWNERS of the security best practices documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,6 @@ docs/developer-docs/updates/release-notes/ @dfinity/dx
 docs/developer-docs/build/agents @dfinity/dx
 docs/developer-docs/build/cdks @dfinity/dx
 docs/developer-docs/integrations/rosetta @dfinity/finint
+docs/developer-docs/security @dfinity/product-security
 
 # Each piece of documentation must be owned by the respective teams


### PR DESCRIPTION
Add product-security as CODEOWNERS of the security best practices documentation