### PR TITLE
chore: add let-else binding to roadmap

### DIFF
--- a/roadmap/5_developer_experience/deployed/9_motoko_let_else_binding.md
+++ b/roadmap/5_developer_experience/deployed/9_motoko_let_else_binding.md
@@ -1,0 +1,11 @@
+---
+title: Motoko let-else Binding
+links:
+Forum
+Link: https://forum.dfinity.org/t/solution-in-moc-0-8-3-let-else-match-and-take-in-motoko-do-for-variants-was-when/13427/6
+Proposal:
+eta: Q1 23
+is_community: true
+---
+This Motoko language feature allows a failure block to be run in case of a binding failure. The main motivation for this
+feature is to avoid deeply nested switch statements that lead to less readable code.


### PR DESCRIPTION
New let binding that allows a failure block to be run in case of a binding failure.

See discussion here: https://github.com/dfinity/motoko/pull/3817 

Feature requested by user on the DFINITY forum: https://forum.dfinity.org/t/solution-in-moc-0-8-3-let-else-match-and-take-in-motoko-do-for-variants-was-when/13427/6 

 Community reaction after release: https://forum.dfinity.org/t/new-let-binding-and-serialization-improvements-motoko-updates/18850