### PR TITLE
chore: add redirect for a broken link

### DIFF
--- a/plugins/utils/redirects.js
+++ b/plugins/utils/redirects.js
@@ -105,6 +105,7 @@ const redirects = `
   /developers-guide/quickstart /docs/current/tutorials/deploy_sample_app
   /docs/current/developer-docs/quickstart/cycles-faucet /docs/current/developer-docs/setup/cycles/cycles-faucet
   /docs/current/developer-docs/quickstart/windows-wsl /docs/current/developer-docs/setup/install/windows-wsl
+  /docs/current/developer-docs/quickstart/hello10mins/ /docs/current/tutorials/deploy_sample_app
   
   /docs/rosetta-api/ledger /docs/current/developer-docs/integrations/ledger/
   /docs/rosetta-api/deploy-new-token /docs/current/developer-docs/integrations/ledger/deploy-new-token


### PR DESCRIPTION
Adds a redirect for `https://internetcomputer.org/docs/current/developer-docs/quickstart/hello10mins/` which is printed when the `dfx new` command completes.