### PR TITLE
chore: move blog link to top navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -403,6 +403,12 @@ const config = {
             label: "Motoko",
           },
           {
+            type: "docSidebar",
+            position: "left",
+            sidebarId: "blog",
+            label: "Blog",
+          },
+          {
             type: "dropdown",
             position: "left",
             label: "Links",
@@ -416,11 +422,6 @@ const config = {
                 label: "SDK Release Notes",
                 type: "doc",
                 docId: "other/updates/release-notes/release-notes",
-              },
-              {
-                label: "Dev Blog",
-                type: "docSidebar",
-                sidebarId: "blog",
               },
               { label: "Developer Tools", to: "/tooling" },
               { label: "Developer Grants", href: "https://dfinity.org/grants" },


### PR DESCRIPTION
Moves the link for the blog from the Links dropdown to the navbar:

<img width="1268" alt="Screenshot 2023-03-23 at 08 50 18" src="https://user-images.githubusercontent.com/98767015/227259425-0966f2c3-7d16-4545-ac81-add9077e30dc.png">
