### PR TITLE
fix: missing Rust code syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -583,6 +583,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['rust'],
       },
       liveCodeBlock: {
         playgroundPosition: "bottom",


### PR DESCRIPTION
### Fix

Rust code syntax is not higlighted because Docusaurus does not enable it per default.

See [Docusaurus documentation](https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages).