### PR TITLE
Fixing broken link for consensus image 

### DIFF
--- a/how-it-works/1_protocol/02_consensus.card.md
+++ b/how-it-works/1_protocol/02_consensus.card.md
@@ -2,7 +2,7 @@
 title: Consensus
 ---
 
-![](/img/how-it-works/consensus.web)
+![](/img/how-it-works/consensus.webp)
 
 # Consensus
 


### PR DESCRIPTION
<img width="657" alt="image" src="https://user-images.githubusercontent.com/105195369/230313500-28176946-5ad5-4255-8abe-65d5ef777c76.png">