### PR TITLE
Correct a typo in `docs/developer-docs/backend/candid/candid-howto.md`

### DIFF
--- a/docs/developer-docs/backend/candid/candid-howto.md
+++ b/docs/developer-docs/backend/candid/candid-howto.md
@@ -55,7 +55,7 @@ For more information about using `dfx` and the `dfx canister call` command, see 
 
 The Candid interface description language provides a common language for specifying the signature of a canister. Based on the type signature of the service offered by the smart contract, Candid provides a web interface—the Candid UI—that allows you to call canister functions for testing and debugging from a web browser without writing any frontend code.
 
-To use the Candid web interface to test the \`counter \`canister:
+To use the Candid web interface to test the `counter` canister:
 
 1.  Find the Candid UI canister identifier associated with the `counter` canister using the `dfx canister id __Candid_UI` command.
 


### PR DESCRIPTION
Typo visible at https://internetcomputer.org/docs/current/developer-docs/backend/candid/candid-howto#interact-with-a-service-from-a-browser