### PR TITLE
Add network=ic to tutorial of top-up cycles

### DIFF
--- a/docs/developer-docs/production/topping-up-canister.md
+++ b/docs/developer-docs/production/topping-up-canister.md
@@ -75,7 +75,7 @@ If you have a cycles wallet you control via dfx, you can send cycles from your c
 
 ```bash
 dfx wallet --network ic balance
-dfx canister deposit-cycles 1000000 jqylk-byaaa-aaaal-qbymq-cai 
+dfx canister --network ic deposit-cycles 1000000 jqylk-byaaa-aaaal-qbymq-cai 
 ```
 
 -   The `wallet --network ic balance` checks the cycles balance of your cycles wallet on mainnet


### PR DESCRIPTION
The original tutorial misses '--network ic' and would lead to an error message as it could only transfer cycles on the local machine

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
