### PR TITLE
Capitalized titles

### DIFF
--- a/docs/developer-docs/backend/choosing-language.md
+++ b/docs/developer-docs/backend/choosing-language.md
@@ -15,11 +15,11 @@ The most common languages to use are:
 - **Motoko**
   - [Motoko](/motoko/main/motoko.md) was [specifically designed](https://stackoverflow.blog/2020/08/24/motoko-the-language-that-turns-the-web-into-a-computer/) by DFINITY to support the unique features of the Internet Computer and to provide a familiar yet robust programming environment.
   - One can use Motoko via the [IC SDK](https://github.com/dfinity/sdk) by DFINITY
-  - See [Introduction to Developing Canisters in Motoko](./motoko/index.md)
+  - See [Introduction to developing canisters in Motoko](./motoko/index.md)
   - You can get a sense of Motoko by using the web-based [Motoko Playground](https://m7sm4-2iaaa-aaaab-qabra-cai.ic0.app)
 - **Rust**
   - One can use Rust via the either the [IC SDK](https://github.com/dfinity/sdk) (typical path for developers) or use the [Rust CDK](https://github.com/dfinity/cdk-rs) by DFINITY. To see difference between SDK and CDK, see: [SDK vs CDK](../setup/install/index.mdx##SDK-vs-CDK)
-  - See [Introduction to Developing Canisters in Rust](./rust/index.md)
+  - See [Introduction to developing canisters in Rust](./rust/index.md)
 - **Python**
   - Python is a readable, versatile language for web development, data analysis, and AI.
   - You can use Python via the [Kybra](https://demergent-labs.github.io/kybra) CDK by [Demergent Labs](https://github.com/demergent-labs)

--- a/docs/developer-docs/backend/motoko/index.md
+++ b/docs/developer-docs/backend/motoko/index.md
@@ -1,4 +1,4 @@
-# Introduction to Developing Canisters in Motoko
+# Introduction to developing canisters in Motoko
 
 [Motoko](/motoko/main/motoko.md) was [specifically designed](https://stackoverflow.blog/2020/08/24/motoko-the-language-that-turns-the-web-into-a-computer/) by DFINITY to support the unique features of the Internet Computer and to provide a familiar yet robust programming environment.
 

--- a/docs/developer-docs/backend/troubleshooting.md
+++ b/docs/developer-docs/backend/troubleshooting.md
@@ -2,7 +2,7 @@
 
 This section provides information to help you troubleshoot and resolve or work around common issues that are related to the following tasks:
 
--   downloading and installing the SDK
+-   downloading and installing the IC SDK
 
 -   creating, building, or deploying canisters
 

--- a/docs/developer-docs/index.md
+++ b/docs/developer-docs/index.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 The [Internet Computer blockchain](https://wiki.internetcomputer.org/wiki/Introduction_to_ICP) is poised to help you start a revolution with a new way to design, build, and release dapps.
 
-## Developing Dapps
+## Developing dapps
 
 The Internet Computer is a blockchain that runs [canister smart contracts](https://internetcomputer.org/how-it-works/architecture-of-the-internet-computer/#canister-smart-contracts), which are code units bundling together WebAssembly bytecode and the memory pages the bytecode runs in. The Internet Computer is composed of individual [subnet blockchains](https://internetcomputer.org/how-it-works/architecture-of-the-internet-computer/#subnet-architecture) running in parallel and connected together by the use of [Chain Key cryptography](https://internetcomputer.org/how-it-works/#Chain-key-cryptography). This means that canisters running on a subnet can seamlessly call canisters hosted in any other subnet of the Internet Computer blockchain. Moreover, the governance system of the Internet Computer can dynamically increase the capacity of the Internet Computer by adding new subnets, allowing dapps to scale out.
 
@@ -13,7 +13,7 @@ Developers can thus build new dapps consisting of multiple canisters running in 
 
 See [Introduction to ICP blockchain](https://wiki.internetcomputer.org/wiki/Introduction_to_ICP) on the IC wiki.
 
-## Developer Workflow at a Glance
+## Developer workflow at a glance
 
 At a high-level, there are two main possible workflows for developing dapps that run on the Internet Computer blockchain.
 
@@ -25,7 +25,7 @@ At a high-level, there are two main possible workflows for developing dapps that
 
 Regardless of the development workflow you choose, keep in mind that when you deploy a canister for the first time, either on a local execution environment or on the Internet Computer, a unique [principal identifier](/references/glossary.md#principal) is created for your canister. For example, if you start developing your canister locally and then deploy it to the Internet Computer, then your canister will generally have a different identifier on the local execution environment and on the Internet Computer blockchain mainnet. Note that it is also possible for you to register a principal identifier for your new canister before deploying it or even writing any line of code.
 
-## Gas cost / Pricing
+## Gas cost / pricing
 
 The Internet Computer is one of the cheapest blockchains that exist today. 
 

--- a/docs/developer-docs/setup/install/windows-wsl.md
+++ b/docs/developer-docs/setup/install/windows-wsl.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 ---
-# Installing the SDK on Windows
+# Installing the IC SDK on Windows
 
 There is no native support for `dfx` on Windows. However, by installing the Windows Subsystem for Linux (WSL), you can run `dfx` also on a Windows system as described below.
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -20,7 +20,7 @@ Install the extension through the [VS Marketplace](https://marketplace.visualstu
 
 [VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
 
-## Keyboard Shortcuts
+## Keyboard shortcuts
 
 Below are the default key bindings for commonly used features supported in the extension:
 

--- a/docs/developer-docs/use-cases/considerations-for-nft-devs.md
+++ b/docs/developer-docs/use-cases/considerations-for-nft-devs.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 ---
-# NFT developement
+# NFT development
 
 ## What is an NFT?
 
@@ -22,7 +22,7 @@ An NFT implementation on the IC typically has the following three functions:
 Depending on the architecture, all of these functions may be in one canister or spread across multiple canisters right up to an asset canister per individual NFT. Each of these canisters must not run out of cycles, and should be protected against arbitrary code changes. In the following, we discuss some of the mechanisms, tools, and ideas that support NFT developers and their users to achieve these goals.
 
 
-## The Basics
+## The basics
 
 ### Top up all canisters very generously
 
@@ -75,7 +75,7 @@ The IC itself does not yet support backup and restoration of the canister state,
 There are dedicated services on the IC to keep an audit log of transactions such as [CAP](https://cap.ooo/), which can be used by an NFT collection as a service. This allows simple integration of the provenance history in explorers and wallets. 
 Furthermore, the state of ownership could be reconstructed in case the main NFT canister gets lost. However, some drawbacks have to be considered, e.g. NFT transfers incur additional costs due to the necessary inter-canister calls. 
 
-## Advanced Topics
+## Advanced topics
 
 ### Think about governance
 
@@ -91,7 +91,7 @@ More information on this topic can be found in the [Trust in Canisters](/concept
 Ideally, your canisters implement mechanisms to generate fees that the canisters can use to pay for their existence indefinitely. A simple approach is to utilize (parts of) the transfer fee to fuel the canisters, but more elaborate schemes could involve staking or other advanced mechanisms. We’re unaware of any good best practices, but please share if you know of projects implementing clever mechanisms.
 
 
-## Links and Resources
+## Links and resources
 
 The following resources are community projects. Please do your own research and use them at your own risk.
 

--- a/docs/samples/deploying-your-first-bitcoin-dapp.md
+++ b/docs/samples/deploying-your-first-bitcoin-dapp.md
@@ -13,7 +13,8 @@ and [Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interf
 
         git clone https://github.com/dfinity/examples
 
-2. Go to the `basic_bitcoin` example in the language of your choice
+2. Go to the `basic_bitcoin` example in the [language of your choice](../developer-docs/backend/choosing-language.md):
+
 
         # For motoko
         cd examples/motoko/basic_bitcoin

--- a/docs/tutorials/01_deploy_sample_app.md.hide
+++ b/docs/tutorials/01_deploy_sample_app.md.hide
@@ -1,11 +1,11 @@
 ---
-title: Tutorial 1 - Deploy a sample app
+title: Tutorial 1 - Deploy a sample dapp
 sidebar_position: 1
 tags:
 - Getting started
 ---
 
-# Create Your First App
+# Create your first dapp
 
 ## Setup
 
@@ -28,7 +28,7 @@ supports the UNIX-specific commands in this tutorial. You can also
 use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 :::
 
-## Create Project
+## Create project
 
 To create an IC dapp, open your terminal, cd into the directory you’d like to create the app in, and run the following
 command:

--- a/docs/tutorials/02_create_your_first_app/01_backend-overview.md
+++ b/docs/tutorials/02_create_your_first_app/01_backend-overview.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 1
-title: Step 1 - Smart Contracts as a backend
+title: Step 1 - Smart contracts as a backend
 ---
 
-# Step 1 - Smart Contracts as a backend
+# Step 1 - Smart contracts as a backend
 
 First, we will create a backend for our application that will be implemented as an ICP 
 [canister smart contract](https://internetcomputer.org/how-it-works/architecture-of-the-internet-computer/#canister-smart-contracts). You can see a preview of the dapp [here](index.md).

--- a/docs/tutorials/02_create_your_first_app/index.md
+++ b/docs/tutorials/02_create_your_first_app/index.md
@@ -1,4 +1,4 @@
-# Tutorial 2 - Create your first app in 10 minutes
+# Tutorial 2 - Create your first dapp in 10 minutes
 
 ## About this tutorial
 

--- a/docs/tutorials/index.mdx
+++ b/docs/tutorials/index.mdx
@@ -7,6 +7,6 @@ This section contains Internet Computer tutorials that will guide developers to 
 
 ### Basic Tutorials
 
-- **[Deploy Sample App](./deploy_sample_app.md)** explains the easiest way to deploy a sample app to the IC wihtout looking into the app code.
-- **[Full App Tutorial](./02_create_your_first_app/index.md)** explains step-by-step process of creating a dapp 
+- **[Deploy a sample app](./deploy_sample_app.md)** explains the easiest way to deploy a sample app to the IC wihtout looking into the app code.
+- **[Full app tutorial](./02_create_your_first_app/index.md)** explains step-by-step process of creating a dapp 
 that contains both backend and frontend components

--- a/docs/tutorials/index.mdx
+++ b/docs/tutorials/index.mdx
@@ -5,8 +5,8 @@ sidebar_position: 0
 
 This section contains Internet Computer tutorials that will guide developers to create and deploy sample applications in a step-by-step mode.
 
-### Basic Tutorials
+### Basic tutorials
 
-- **[Deploy a sample app](./deploy_sample_app.md)** explains the easiest way to deploy a sample app to the IC wihtout looking into the app code.
-- **[Full app tutorial](./02_create_your_first_app/index.md)** explains step-by-step process of creating a dapp 
+- **[Deploy a sample dapp](./deploy_sample_app.md)** explains the easiest way to deploy a sample app to the IC without looking into the app code.
+- **[Full dapp tutorial](./02_create_your_first_app/index.md)** explains step-by-step process of creating a dapp 
 that contains both backend and frontend components

--- a/src/components/DocsHome/DevGuides/index.tsx
+++ b/src/components/DocsHome/DevGuides/index.tsx
@@ -30,7 +30,7 @@ function Index() {
         </SmallCard>
         <SmallCard
           href="/docs/current/developer-docs/backend/choosing-language"
-          title="Build a Smart Contract backend"
+          title="Build a smart contract backend"
         >
           Learn how to create canister smart contracts with your language of choice
         </SmallCard>


### PR DESCRIPTION
Updating some titles so they follow the standards for documentation. 

Before: Every word in a title was capitalized.

Now: Only the first word and proper nouns are capitalized.