### PR TITLE
chore: hide empty toc on blog pages

### DIFF
--- a/src/css/blog.scss
+++ b/src/css/blog.scss
@@ -1,0 +1,8 @@
+html.plugin-blog {
+  main[class*="docMainContainer_"] {
+    // remove empty ToC and allow blog content to take up remaining width on screen
+    .col.col--3:empty {
+      display: none;
+    }
+  }
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -44,6 +44,7 @@
 }
 
 @import "./animate.scss";
+@import "./blog.scss";
 @import "./code.scss";
 @import "./navbar.scss";
 @import "./scrollbar.scss";


### PR DESCRIPTION
ToC is empty on the blog pages, but it still takes up space. This PR hides the space by targeting the empty div and setting `display: none`