### PR TITLE
fix broken links

### DIFF
--- a/docs/developer-docs/integrations/https-outcalls/https-outcalls-get.md
+++ b/docs/developer-docs/integrations/https-outcalls/https-outcalls-get.md
@@ -509,3 +509,8 @@ Open the candid web UI for the backend (the `hello_http_rust_backend` one) and c
 :::note
 In both the Rust and Motoko minimal examples, we did not create a **transform** function so that it transforms the raw response. This is something we will explore in a future section
 :::
+
+## Additional resources
+
+* Sample code of [HTTP GET requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_get)
+* Sample code of [HTTP GET requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_get)

--- a/docs/developer-docs/integrations/https-outcalls/https-outcalls-post.md
+++ b/docs/developer-docs/integrations/https-outcalls/https-outcalls-post.md
@@ -515,3 +515,8 @@ Open the candid web UI for backend and call the `send_http_post_request()` metho
 :::note
 In both the Rust and Motoko minimal examples, we did not create a **transform** function so that it transforms the raw response. This is something we will explore in a following section
 :::
+
+## Additional resources
+
+* Sample code of [HTTP POST requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_post)
+* Sample code of [HTTP POST requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_post)

--- a/docs/developer-docs/integrations/https-outcalls/index.md
+++ b/docs/developer-docs/integrations/https-outcalls/index.md
@@ -32,4 +32,8 @@ We expect the majority of HTTP calls to be `GET` calls for reading Web 2.0 data,
 
 - If you want to take a deep dive into how the HTTPS outcalls feature works and how to use it when coding a canister, see the [how it works](https-outcalls-how-it-works.md) section.
 
-- In the [examples repository](https://github.com/dfinity/examples) you can find [sample code in Rust](https://github.com/dfinity/examples/tree/master/rust/https_outcalls_GET_request) and [Motoko](https://github.com/dfinity/examples/tree/master/motoko/exchange_rate) which you can use as starting point for building your own dApp.
+- In the [examples repository](https://github.com/dfinity/examples) you can find sample code which you can use as starting point for building your own dApp.:
+    * Sample code for making [HTTP GET requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_get) 
+    * Sample code for making [HTTP GET requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_get) 
+     * Sample code for making [HTTP POST requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_post) 
+    * Sample code for making [HTTP POST requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_post)

--- a/docs/developer-docs/integrations/https-outcalls/index.md
+++ b/docs/developer-docs/integrations/https-outcalls/index.md
@@ -35,5 +35,5 @@ We expect the majority of HTTP calls to be `GET` calls for reading Web 2.0 data,
 - In the [examples repository](https://github.com/dfinity/examples) you can find sample code which you can use as starting point for building your own dApp.:
     * Sample code for making [HTTP GET requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_get) 
     * Sample code for making [HTTP GET requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_get) 
-     * Sample code for making [HTTP POST requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_post) 
+    * Sample code for making [HTTP POST requests in Rust](https://github.com/dfinity/examples/tree/master/rust/send_http_post) 
     * Sample code for making [HTTP POST requests in Motoko](https://github.com/dfinity/examples/tree/master/motoko/send_http_post)

--- a/src/components/Common/sampleItems.ts
+++ b/src/components/Common/sampleItems.ts
@@ -95,12 +95,12 @@ export const sampleItems: SampleItem[] = [
     links: {
       action: {
         text: "Get Code",
-        to: "https://github.com/dfinity/examples/tree/master/motoko/https_outcalls_GET_request",
+        to: "https://github.com/dfinity/examples/tree/master/motoko/send_http_get",
       },
       motoko:
-      "https://github.com/dfinity/examples/tree/master/motoko/https_outcalls_GET_request",
+      "https://github.com/dfinity/examples/tree/master/motoko/send_http_get",
       docs: "docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-to-use",
-      rust: "https://github.com/dfinity/examples/tree/master/rust/https_outcalls_GET_request",
+      rust: "https://github.com/dfinity/examples/tree/master/rust/send_http_get",
     },
   },
   {


### PR DESCRIPTION
The `/examples` repo was updated today with new dapps and deleted some other ones so I am pushing some changes to make sure the links from `/portal` to `/examples` still match.