### PR TITLE
Redirect broken link for HTTPS outcalls

### DIFF
--- a/plugins/utils/redirects.js
+++ b/plugins/utils/redirects.js
@@ -28,6 +28,7 @@ const redirects = `
   /docs/security-best-practices/introduction /docs/current/developer-docs/security/
   /docs/current/developer-docs/setup/default-wallet /docs/current/developer-docs/setup/cycles/
   /docs/current/tokenomics/sns/tokenomics /docs/current/developer-docs/integrations/sns/tokenomics/
+  /docs/current/developer-docs/integrations/http_requests/http_requests-how-it-works /docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works
   /docs/current/developer-docs/integrations/sns/tokenomics/sns-intro-tokens /docs/current/developer-docs/integrations/sns/tokenomics/
   /docs/current/developer-docs/integrations/sns/tokenomics/tokenomics /docs/current/developer-docs/integrations/sns/tokenomics/tokenomics-intro
   /docs/rust-guide/rust-intro /docs/current/developer-docs/backend/rust/


### PR DESCRIPTION
I recently came across this broken link in a Google search related to HTTPS outcalls:

https://internetcomputer.org/docs/current/developer-docs/integrations/http_requests/http_requests-how-it-works

This PR adds a redirect to the following page:

https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works