### PR TITLE
chore: add a missing redirect to storage costs

### DIFF
--- a/plugins/utils/redirects.js
+++ b/plugins/utils/redirects.js
@@ -10,6 +10,7 @@ const redirects = `
   /docs/current/concepts/bitcoin-integration /bitcoin-integration
   /docs/current/developer-docs/ic-overview /docs/current/developer-docs/
   /docs/current/developer-docs/production/computation-and-storage-costs /docs/current/developer-docs/gas-cost
+  /docs/current/developer-docs/deploy/computation-and-storage-costs /docs/current/developer-docs/gas-cost
   /docs/current/ic-overview  /docs/current/home
   /docs/download /docs/current/developer-docs/setup/install/
   /docs/http-middleware /docs/current/home


### PR DESCRIPTION
https://internetcomputer.org/docs/current/developer-docs/deploy/computation-and-storage-costs used to point to the cycle costs page. This change adds a redirect to this page's new location.