### PR TITLE
Mark DTS as deployed in the roadmap

### DIFF
--- a/roadmap/1_core-protocol/deployed/05_deterministic-time-slicing.md
+++ b/roadmap/1_core-protocol/deployed/05_deterministic-time-slicing.md
@@ -13,4 +13,4 @@ Deterministic time slicing allows for long(er) running, multi-round computations
 The feature is currently enabled on all application and verified application subnets.
 All messages except for queries are automatically sliced and executed in multiple rounds.
 The instruction limit for such messages has been increased from 5 billion instructions to 20 billion instructions.
-Further increases are blocked by the "Configurable Wasm Heap Limit" feature.
+Further increases will follow after the "Configurable Wasm Heap Limit" feature ships.


### PR DESCRIPTION
The remaining increase of the message instruction limit from 20B to 40B
is extracted out of DTS scope. It will be done as a follow-up after
"Configurable Wasm Heap Limit".

This means that DTS can be moved to deployed.

