### PR TITLE
Add documentation for `mo-doc` command

### DIFF
--- a/docs/developer-docs/backend/motoko/mo-doc.md
+++ b/docs/developer-docs/backend/motoko/mo-doc.md
@@ -33,16 +33,16 @@ $(dfx cache show)/mo-doc [options]
    mo-doc
    ```
 
-2. Generate Markdown documentation from a specific source directory and place it in a custom output directory:
+2. Generate AsciiDoc documentation from a specific source directory:
 
    ```bash
-   mo-doc --format plain --source ./motoko-code --output ./motoko-docs
+   mo-doc --format plain --source ./motoko-code
    ```
 
-3. Generate plain text documentation from a source directory:
+3. Generate Markdown documentation in a custom output directory:
 
    ```bash
-   mo-doc --source ./src --format plain
+   mo-doc --format adoc --output ./public
    ```
 
 ## Writing Doc Comments
@@ -64,6 +64,6 @@ func factorial(n : Nat) : ?Nat {
 }
 ```
 
-Check out Motoko's [base library souce code](https://github.com/dfinity/motoko-base/tree/master/src) for examples and best practices. 
+Check out Motoko's [base library souce code](https://github.com/dfinity/motoko-base/tree/master/src) for additional examples and best practices. 
 
 The source code for `mo-doc` is available in the [dfinity/motoko](https://github.com/dfinity/motoko/tree/master/src/docs) GitHub repository. Contributions are welcome!

--- a/docs/developer-docs/backend/motoko/mo-doc.md
+++ b/docs/developer-docs/backend/motoko/mo-doc.md
@@ -1,0 +1,69 @@
+# `mo-doc`
+
+`mo-doc` is a command-line tool for generating documentation for Motoko source code. It processes source files and generates documentation in various formats. 
+
+## Quick Start
+
+Download `mo-doc` from Motoko's [GitHub releases page](https://github.com/dfinity/motoko/releases) or simply use the binary included in your [dfx](https://internetcomputer.org/docs/current/developer-docs/setup/install) installation:
+
+```
+$(dfx cache show)/mo-doc [options]
+```
+
+## Options
+
+- `--source <path>`: Specifies the directory to search for Motoko source files. Defaults to `src`.
+
+- `--output <path>`: Specifies the directory where the documentation will be generated. Defaults to `docs`.
+
+- `--format <format>`: Specifies the generated format. Should be one of the following:
+  - `html`: Generates HTML format documentation.
+  - `adoc`: Generates AsciiDoc format documentation.
+  - `plain`: Generates Markdown documentation.
+  
+  Defaults to `html`.
+
+- `--help`: Shows usage information.
+
+## Examples
+
+1. Generate HTML documentation from the default source directory (`src`) and place it in the default output directory (`docs`):
+
+   ```bash
+   mo-doc
+   ```
+
+2. Generate Markdown documentation from a specific source directory and place it in a custom output directory:
+
+   ```bash
+   mo-doc --format plain --source ./motoko-code --output ./motoko-docs
+   ```
+
+3. Generate plain text documentation from a source directory:
+
+   ```bash
+   mo-doc --source ./src --format plain
+   ```
+
+## Writing Doc Comments
+
+`mo-doc` supports documenting your Motoko code using special block comments (`/** */`) and line comments (`///`).
+
+Doc comments can be used to provide explanations for functions, classes, types, modules, variables, and more. They can span multiple lines and may contain rich Markdown formatting:
+
+```motoko
+/// Calculate the factorial of a given positive integer.
+/// 
+/// Example:
+/// ```motoko
+/// factorial(0); // => null
+/// factorial(3); // => ?6
+/// ```
+func factorial(n : Nat) : ?Nat {
+    // ...
+}
+```
+
+Check out Motoko's [base library souce code](https://github.com/dfinity/motoko-base/tree/master/src) for examples and best practices. 
+
+The source code for `mo-doc` is available in the [dfinity/motoko](https://github.com/dfinity/motoko/tree/master/src/docs) GitHub repository. Contributions are welcome!

--- a/docs/developer-docs/backend/motoko/mo-doc.md
+++ b/docs/developer-docs/backend/motoko/mo-doc.md
@@ -1,4 +1,4 @@
-# Generating Motoko Documentation
+# Generating Motoko documentation
 
 `mo-doc` is a command-line tool for generating documentation for Motoko source code. It processes source files and generates documentation in various formats. 
 

--- a/docs/developer-docs/backend/motoko/mo-doc.md
+++ b/docs/developer-docs/backend/motoko/mo-doc.md
@@ -1,4 +1,4 @@
-# `mo-doc`
+# Generating Motoko Documentation
 
 `mo-doc` is a command-line tool for generating documentation for Motoko source code. It processes source files and generates documentation in various formats. 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -236,6 +236,7 @@ const sidebars = {
                 "developer-docs/backend/motoko/candid-ui",
                 "developer-docs/backend/motoko/scalability-cancan",
                 "developer-docs/backend/motoko/sample-apps",
+                "developer-docs/backend/motoko/mo-doc",
               ],
             },
             {


### PR DESCRIPTION
This PR adds a documentation page for the `mo-doc` command packaged with `dfx`. 

CC @letmejustputthishere
