### PR TITLE
update developer docs for 1proposal flow

### DIFF
--- a/docs/developer-docs/integrations/sns/launching/index.md
+++ b/docs/developer-docs/integrations/sns/launching/index.md
@@ -1,18 +1,13 @@
 # Launching an SNS
 
 This Section describes the SNS launch process in detail.
-It starts with a detailed description of all [Stages of an SNS launch](./launch-summary.md).
-Then, it explains the practical [commands & actions to go through SNS launch](./launch-steps.md), in terms of concrete tools and commands that are needed to take a project through all of these stages and launch an SNS for it.
-
-<!-- NEW: 
 It starts with a detailed description of all Stages of an SNS launch.
 Then, it explains the practical commands & actions to go through SNS launch, in terms of concrete tools and commands that are needed to take a project through all of these stages and launch an SNS for it.
 
-On August 14th, 2023, the NNS has decided to release a new version of the SNS with a new, simplified launch process. In particular, the new launch process only requires one single NNS proposal that will, if adopted, trigger the creation of the SNS canisters as well as starting and finishing the decentralization swap. Since the new flow is considerably simpler both for developers who want to hand over their dapp to the IC and for voters/users, it is recommended to use the new flow.
+In August 2023, the NNS has decided to release a new version of the SNS with a new, simplified launch process. In particular, the new launch process only requires one single NNS proposal that will, if adopted, trigger the creation of the SNS canisters as well as starting and finishing the decentralization swap. Since the new flow is considerably simpler both for developers who want to hand over their dapp to the IC and for voters/users, it is recommended to use the new flow.
 
-As some dapp projects might already have started with planning and testing the SNS launch process, the old legacy flow is still supported.  Note that the legacy flow might be deprecated going forward.
+As some dapp projects might already have started with planning and testing the SNS launch process, the old legacy flow is still supported. Note that the legacy flow might be deprecated going forward.
 
 Therefore, the developer documentation currently includes pages to describe both the old and the new flow.
 The pages [Stages of an SNS launch](./launch-summary-1proposal.md) and [Commands & actions to go through SNS launch](./launch-steps-1proposal.md) define the new, recommended launch flow and how to go through it.
 The pages [Stages of an SNS launch](./launch-summary.md) and [Commands & actions to go through SNS launch](./launch-steps.md) define the old, legacy flow that might be deprecated going forward.
--->


### PR DESCRIPTION
Update the developer documentation to the new 1proposal flow. This PR should only be merged if and when the NNS decides to enable the new 1proposal flow. 