### PR TITLE
Security best practices for HTTP outcalls

### DIFF
--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.md
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.md
@@ -478,15 +478,15 @@ By default, the data stored inside your canister is unencrypted. Therefore if yo
 
 Make sure you don’t store sensitive data inside your canister.
 
-[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#compromised-replicas)
+[More information.](../integrations/https-outcalls/https-outcalls-how-it-works#compromised-replicas)
 
-[Data confidentiality security recommendations.](https://internetcomputer.org/docs/current/developer-docs/security/general-security-best-practices#data-confidentiality-on-the-internet-computer)
+[Data confidentiality security recommendations.](general-security-best-practices#data-confidentiality-on-the-internet-computer)
 
 ### Ensure your canisters have a sufficiently large quota with the HTTP server
 
 #### Security concern
 
-When an HTTP outcall is performed it is amplified by the number of replicas in the subnet. The endpoint will receive not one request but as many requests as nodes in the subnet.
+When an HTTP outcall is performed it is amplified by the number of replicas in the subnet. The target web server will receive not only one request but as many requests as the number of nodes in the subnet.
 
 Most web servers implement some sort of rate limiting, this is a mechanism used to restrict the number of requests a client can make to a web server within a specific time period, preventing abuse or excessive usage of their API(s).
 
@@ -494,7 +494,7 @@ Most web servers implement some sort of rate limiting, this is a mechanism used 
 
 You should consider such rate limits when designing and implementing your canisters. Rate limits are enforced using different time granularities, e.g., seconds or minutes. For second-granularity enforcement, make sure that the simultaneous requests by all subnet replicas do not violate the quota. Violations may lead to temporary or permanent bans.
 
-[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#rate-limiting-by-servers)
+[More information.](../integrations/https-outcalls/https-outcalls-how-it-works#rate-limiting-by-servers)
 
 ### Only make HTTP outcall requests to idempotent endpoints
 
@@ -508,39 +508,39 @@ Make sure the endpoints, called by an HTTP outcall, are idempotent, i.e. the que
 
 Some servers support the use of idempotency keys. These keys are random unique strings submitted in the HTTP request as headers. If used with the HTTP outcalls feature, all requests sent by each (honest) replica will contain the same idempotency key. This allows the server to recognize duplicated requests (i.e requests with the same idempotency key), handle just one and modify the server state only once. Note that this is a feature that must be supported by the server.
 
-[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#post-requests-must-be-idempotent)
+[More information.](../integrations/https-outcalls/https-outcalls-how-it-works#post-requests-must-be-idempotent)
 
 ### Ensure HTTP responses are identical
 
 #### Security concern
 
-When replicas of a subnet receive HTTP responses, these responses must be identical. Otherwise the consensus won’t be achieved and the HTTP response will be rejected, but still charged.
+When replicas of a subnet receive HTTP responses, these responses must be identical. Otherwise, consensus won’t be achieved and the HTTP response will be rejected, but still charged.
 
 #### Recommendation
 
 Make sure the HTTP responses sent to the consensus layer are identical.
 
-Ideally the HTTP responses returned by the queried endpoint would be always the same. However most of the time this is not possible to control and the responses include random data (e.g the response includes timestamps, cookie values or some sort of identifiers). In those cases make sure to use the [transformation functions](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#transformation-function) to guarantee that the responses, received by each replica, are identical by removing any random data or extracting only the relevant data.
+Ideally the HTTP responses returned by the queried endpoint would always be the same. However, most of the time this is not possible to control and the responses include random data (e.g the response includes timestamps, cookie values or some sort of identifiers). In those cases make sure to use the [transformation functions](../integrations/https-outcalls/https-outcalls-how-it-works#transformation-function) to guarantee that the responses received by each replica are identical by removing any random data or extracting only the relevant data.
 
-This applies to the HTTP response body and header. Make sure to consider both when applying the transformation functions. Response headers are often overlooked and lead to failure because of failed consensus.
+This applies to the HTTP response body and headers. Make sure to consider both when applying the transformation functions. Response headers are often overlooked and lead to failure because of failed consensus.
 
-[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#responses-must-be-similar)
+[More information.](../integrations/https-outcalls/https-outcalls-how-it-works#responses-must-be-similar)
 
 ### Be aware of HTTP request and response sizes
 
 #### Security concern
 
-HTTP outcalls [pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#pricing) is determined by, among other variables, the size of the HTTP request and the maximal response size. Thus, if big requests are made, this could quickly drain the canister’s cycles balance. This can be risky e.g. HTTP outcalls are triggered by user actions (rather than a heartbeat or timer invocation).
+HTTP outcalls [pricing](../integrations/https-outcalls/https-outcalls-how-it-works#pricing) is determined by, among other variables, the size of the HTTP request and the maximal response size. Thus, if big requests are made, this could quickly drain the canister’s cycles balance. This can be risky e.g. if HTTP outcalls are triggered by user actions (rather than a heartbeat or timer invocation).
 
 #### Recommendation
 
 When using HTTPS outcalls be mindful of the HTTP request and response sizes. Ensure that the size of the request issued and the size of the HTTP response coming from the server are reasonable.
 
-When making an HTTP outcall it is possible – and highly recommended – to define the `max_response_bytes` parameter, which allows you to set the maximum response size of the server's response. If this parameter is not defined, it defaults to 2MB (the hard response size limit of the HTTPS outcalls functionality). The cycle cost of the response is always charged based on the `max_response_bytes` or 2MB if not set.
+When making an HTTP outcall it is possible – and highly recommended – to define the `max_response_bytes` parameter, which allows you to set the maximum allowed response size. If this parameter is not defined, it defaults to 2MB (the hard response size limit of the HTTPS outcalls functionality). The cycle cost of the response is always charged based on the `max_response_bytes` or 2MB if not set.
 
 Finally, be aware that users may incur cycles costs for HTTP outcalls in case these calls can be triggered by user actions.
 
-[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#recipe-for-coding-a-canister-http-call)
+[More information.](../integrations/https-outcalls/https-outcalls-how-it-works#recipe-for-coding-a-canister-http-call)
 
 ### Perform input validation in HTTP outcalls
 

--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.md
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.md
@@ -486,9 +486,9 @@ Make sure you don’t store sensitive data inside your canister.
 
 #### Security concern
 
-When an HTTP outcall is performed it is amplified by the number of replicas in the subnet. The target web server will receive not only one request but as many requests as the number of nodes in the subnet.
+When an HTTP outcall is performed, it is amplified by the number of replicas in the subnet. The target web server will receive not only one request, but as many requests as the number of nodes in the subnet.
 
-Most web servers implement some sort of rate limiting, this is a mechanism used to restrict the number of requests a client can make to a web server within a specific time period, preventing abuse or excessive usage of their API(s).
+Most web servers implement some sort of rate limiting; this is a mechanism used to restrict the number of requests a client can make to a web server within a specific time period, preventing abuse or excessive usage of their API(s).
 
 #### Recommendation
 
@@ -500,7 +500,7 @@ You should consider such rate limits when designing and implementing your canist
 
 #### Security concern
 
-As mentioned before, if an HTTP outcall is performed it is amplified by the number of replicas in the subnet. That means the queried endpoint will receive the same request several times. This is especially risky in requests that change the endpoint state given one HTTP outcall could lead to unintentionally changing the endpoint state several times.
+As mentioned before, if an HTTP outcall is performed it is amplified by the number of replicas in the subnet. That means the queried endpoint will receive the same request several times. This is especially risky in requests that change the endpoint state, given that one HTTP outcall could lead to unintentionally changing the endpoint state several times.
 
 #### Recommendation
 
@@ -530,7 +530,7 @@ This applies to the HTTP response body and headers. Make sure to consider both w
 
 #### Security concern
 
-HTTP outcalls [pricing](../integrations/https-outcalls/https-outcalls-how-it-works#pricing) is determined by, among other variables, the size of the HTTP request and the maximal response size. Thus, if big requests are made, this could quickly drain the canister’s cycles balance. This can be risky e.g. if HTTP outcalls are triggered by user actions (rather than a heartbeat or timer invocation).
+The [pricing](../integrations/https-outcalls/https-outcalls-how-it-works#pricing) of HTTPS outcalls is determined by, among other variables, the size of the HTTP request and the maximal response size. Thus, if big requests are made, this could quickly drain the canister’s cycles balance. This can be risky e.g. if HTTP outcalls are triggered by user actions (rather than a heartbeat or timer invocation).
 
 #### Recommendation
 

--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.md
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.md
@@ -461,6 +461,99 @@ Using the rust CDK, the reccuring timer is also lost on upgrade as explained in 
 - See the Motoko documentation on [recurringTimer](../../motoko/main/base/Timer.md#function-recurringtimer).
 - See the Rust documentation on [set_timer_interval](https://docs.rs/ic-cdk/0.6.9/ic_cdk/timer/fn.set_timer_interval.html).
 
+## HTTP Outcalls
+
+### Do not store sensitive data (e.g. API keys) in canisters
+
+#### Security concern
+
+Sensitive data is a broad term that varies depending on your application logic and behaviour. Here is a non-exhaustive list of secrets that are typically considered sensitive, such as API keys or tokens:
+* Secrets that allow interaction with non-public endpoints.
+* Secrets that allow querying or modifying endpoints with confidential data.
+* API tokens that are fee-based.
+
+By default, the data stored inside your canister is unencrypted. Therefore if your canister is installed in a malicious replica, it can easily retrieve and steal your keys, tokens, and secrets in plain text.
+
+#### Recommendation
+
+Make sure you don’t store sensitive data inside your canister.
+
+[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#compromised-replicas)
+
+[Data confidentiality security recommendations.](https://internetcomputer.org/docs/current/developer-docs/security/general-security-best-practices#data-confidentiality-on-the-internet-computer)
+
+### Ensure your canisters have a sufficiently large quota with the HTTP server
+
+#### Security concern
+
+When an HTTP outcall is performed it is amplified by the number of replicas in the subnet. The endpoint will receive not one request but as many requests as nodes in the subnet.
+
+Most web servers implement some sort of rate limiting, this is a mechanism used to restrict the number of requests a client can make to a web server within a specific time period, preventing abuse or excessive usage of their API(s).
+
+#### Recommendation
+
+You should consider such rate limits when designing and implementing your canisters. Rate limits are enforced using different time granularities, e.g., seconds or minutes. For second-granularity enforcement, make sure that the simultaneous requests by all subnet replicas do not violate the quota. Violations may lead to temporary or permanent bans.
+
+[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#rate-limiting-by-servers)
+
+### Only make HTTP outcall requests to idempotent endpoints
+
+#### Security concern
+
+As mentioned before, if an HTTP outcall is performed it is amplified by the number of replicas in the subnet. That means the queried endpoint will receive the same request several times. This is especially risky in requests that change the endpoint state given one HTTP outcall could lead to unintentionally changing the endpoint state several times.
+
+#### Recommendation
+
+Make sure the endpoints, called by an HTTP outcall, are idempotent, i.e. the queried endpoint has the same behaviour with the same request payload, no matter the number of times it is called.
+
+Some servers support the use of idempotency keys. These keys are random unique strings submitted in the HTTP request as headers. If used with the HTTP outcalls feature, all requests sent by each (honest) replica will contain the same idempotency key. This allows the server to recognize duplicated requests (i.e requests with the same idempotency key), handle just one and modify the server state only once. Note that this is a feature that must be supported by the server.
+
+[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#post-requests-must-be-idempotent)
+
+### Ensure HTTP responses are identical
+
+#### Security concern
+
+When replicas of a subnet receive HTTP responses, these responses must be identical. Otherwise the consensus won’t be achieved and the HTTP response will be rejected, but still charged.
+
+#### Recommendation
+
+Make sure the HTTP responses sent to the consensus layer are identical.
+
+Ideally the HTTP responses returned by the queried endpoint would be always the same. However most of the time this is not possible to control and the responses include random data (e.g the response includes timestamps, cookie values or some sort of identifiers). In those cases make sure to use the [transformation functions](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#transformation-function) to guarantee that the responses, received by each replica, are identical by removing any random data or extracting only the relevant data.
+
+This applies to the HTTP response body and header. Make sure to consider both when applying the transformation functions. Response headers are often overlooked and lead to failure because of failed consensus.
+
+[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#responses-must-be-similar)
+
+### Be aware of HTTP request and response sizes
+
+#### Security concern
+
+HTTP outcalls [pricing](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#pricing) is determined by, among other variables, the size of the HTTP request and the maximal response size. Thus, if big requests are made, this could quickly drain the canister’s cycles balance. This can be risky e.g. HTTP outcalls are triggered by user actions (rather than a heartbeat or timer invocation).
+
+#### Recommendation
+
+When using HTTPS outcalls be mindful of the HTTP request and response sizes. Ensure that the size of the request issued and the size of the HTTP response coming from the server are reasonable.
+
+When making an HTTP outcall it is possible – and highly recommended – to define the `max_response_bytes` parameter, which allows you to set the maximum response size of the server's response. If this parameter is not defined, it defaults to 2MB (the hard response size limit of the HTTPS outcalls functionality). The cycle cost of the response is always charged based on the `max_response_bytes` or 2MB if not set.
+
+Finally, be aware that users may incur cycles costs for HTTP outcalls in case these calls can be triggered by user actions.
+
+[More information.](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-it-works#recipe-for-coding-a-canister-http-call)
+
+### Perform input validation in HTTP outcalls
+
+#### Security concern
+
+HTTP outcalls that use user-submitted data are susceptible to various injection attacks. This may lead to several issues, such as the ones previously mentioned.
+
+#### Recommendation
+
+Perform input validation when using user-submitted data in the HTTP outcalls.
+
+[More information.](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html)
+
 ## Miscellaneous
 
 ### Test your canister code even in presence of system API calls


### PR DESCRIPTION
Adding security best practices for the HTTP Outcalls inside the `rust-canister-development-security-best-practices.md` section.

The list of recommendations is:
- Do not store sensitive data (e.g. API keys) in canisters
- Ensure your canisters have a sufficiently large quota with the HTTP server
- Only make HTTP outcall requests to idempotent endpoints
- Ensure HTTP responses are identical
- Be aware of HTTP request and response sizes
- Perform input validation in HTTP outcalls

The idea is to have a short description of the problem + recommendation and link to the general HTTP outcalls documentation where they detail each problem.