### PR TITLE
Update exchange-rate-canister.md

### DIFF
--- a/docs/developer-docs/integrations/exchange-rate/exchange-rate-canister.md
+++ b/docs/developer-docs/integrations/exchange-rate/exchange-rate-canister.md
@@ -40,12 +40,12 @@ type GetExchangeRateResult = variant {
 ## Cycles cost 
 Each request to the XRC costs 10B cycles to submit the request, otherwise an `ExchangeRateError::NotEnoughCycles` error will be returned. The actual cycles cost of the request call will depend on two factors: the requested asset types and the state of the internal exchange rate cache. These parameters are as follows:
 
-- If the request can be served from the cache, the actual cost is 200M cycles.
-- If both assets are fiat currencies, the cost is 200M cycles.
-- If one of the assets is a fiat currency or the cryptocurrency USDT, the cost is 0.26B cycles.
-- If both assets are cryptocurrencies, the cost is 0.5B cycles.
+- If the request can be served from the cache, the actual cost is 20M cycles.
+- If both assets are fiat currencies, the cost is 20M cycles.
+- If one of the assets is a fiat currency or the cryptocurrency USDT, the cost is 260M cycles.
+- If both assets are cryptocurrencies, the cost is 500M cycles.
 
-The remaining cycles are returned to the requesting canister. Note that at least 10M cycles are charged even in case of an error in order to mitigate the risk of a denial-of-service attack.
+The remaining cycles are returned to the requesting canister. Note that at least 1M cycles are charged even in case of an error in order to mitigate the risk of a denial-of-service attack.
 
 :::info
 Note: The cycles cost of these requests are expected to be decreased in the next upgrade of the XRC. 

--- a/docs/developer-docs/integrations/exchange-rate/exchange-rate-canister.md
+++ b/docs/developer-docs/integrations/exchange-rate/exchange-rate-canister.md
@@ -42,8 +42,8 @@ Each request to the XRC costs 10B cycles to submit the request, otherwise an `Ex
 
 - If the request can be served from the cache, the actual cost is 200M cycles.
 - If both assets are fiat currencies, the cost is 200M cycles.
-- If one of the assets is a fiat currency or the cryptocurrency USDT, the cost is 2.6B cycles.
-- If both assets are cryptocurrencies, the cost is 5B cycles.
+- If one of the assets is a fiat currency or the cryptocurrency USDT, the cost is 0.26B cycles.
+- If both assets are cryptocurrencies, the cost is 0.5B cycles.
 
 The remaining cycles are returned to the requesting canister. Note that at least 10M cycles are charged even in case of an error in order to mitigate the risk of a denial-of-service attack.
 


### PR DESCRIPTION
Corrections in cycle costs.

- If one of the assets is a fiat currency or the cryptocurrency USDT, the cost is 260M cycles.
- If both assets are cryptocurrencies, the cost is 500M cycles.

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
