### PR TITLE
Update preview-deployment.yml to change preview deployment URL

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -98,7 +98,7 @@ jobs:
             const comments = require('./.github/workflows/scripts/comments.js');
             const maybeComment = await comments.get(context, github);
             if (maybeComment) {
-              await comments.update(context, github, maybeComment.id,  `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.ic0.app`);
+              await comments.update(context, github, maybeComment.id,  `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.icp0.io`);
             } else {
-              await comments.create(context, github, `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.ic0.app`);
+              await comments.create(context, github, `🤖 Here's your preview: https://${process.env.PREVIEW_CANISTER_ID}.icp0.io`);
             }


### PR DESCRIPTION
The current link to the deployed previews results in an nginx 404 error because the default domain of the ICP has been changed to `icp0.io` for new deployments. Each preview is a new deployment, hence the current link does not work.

Changes:
- Change ICP default domain from `ic0.app` to `icp0.io` for previews.
