### PR TITLE
Stable memory docs enhancements

### DIFF
--- a/docs/developer-docs/backend/motoko/upgrading.md
+++ b/docs/developer-docs/backend/motoko/upgrading.md
@@ -5,6 +5,8 @@ Upgrading a canister allows you to preserve the existing state of a deployed can
 
 Motoko provides high-level support for preserving a canister's state using the Internet Computer's stable memory through a feature known as stable storage. This feature is designed to accommodate changes to both the Motoko compiler and the application data. 
 
+Stable storage is a Motoko-specific feature that uses the IC's stable memory data persistence feature. Stable memory is used to store data that persists across canister upgrades. The maximum data storage size of stable memory is 96GiB if the subnet can accomodate it. In comparison, heap storage refers to the regular Wasm data storage for a canister. Heap storage is not persisted across canister upgrades and is limited to 4GiB. 
+
 Consider the following example: you have a dapp that manages professional profiles and social connections. To add a new feature to the dapp, you need to be able to update the canister code without losing any of the previously stored data. A canister upgrade enables you to update existing canister identifiers with program changes without losing the program state.
 
 To preserve state when you are upgrading a canister written in Motoko, be sure to use the stable keyword to identify the variables you want to preserve. For more information about preserving variable state in Motoko, see [stable variables and upgrade methods](https://internetcomputer.org/docs/current/motoko/main/upgrades). 

--- a/docs/developer-docs/backend/rust/7-upgrading.md
+++ b/docs/developer-docs/backend/rust/7-upgrading.md
@@ -8,12 +8,17 @@ For example, assume you have a dapp that manages professional profiles and socia
 
 ## Canister upgrades
 When a canister needs to be upgraded, the following workflow is used:
+- If a `pre_upgrade` hook is defined, the system calls it. Note: Having a `pre_upgrade` hook is not recommended, since the `pre_upgrade` hook is run in the current Wasm. If there are any bugs or errors, the canister will trap. 
 - The system calls a `pre_upgrade` hook if your canister defines it.
 - The system discards canister memory and instantiates the new version of your WebAssembly module. The system does preserve the stable memory, which is now available to the new version.
 - The system calls a `post_upgrade` hook on the newly created instance if your canister defines it. The `init` function is not executed.
 - If the canister traps (throws an unrecoverable error) in any of the steps above, the system reverts the canister to the pre-upgrade state.
 
 ### Versioning stable memory
+
+Stable memory is a data persistence feature on the IC. Stable memory is used to store data that persists across canister upgrades. The maximum data storage size of stable memory is 96GiB if the subnet can accomodate it. 
+
+In comparison, heap storage refers to the regular Wasm data storage for a canister. Heap storage is not persisted across canister upgrades and is limited to 4GiB. 
 
 Stable memory can be viewed as the communication channel between old and new versions of a canister. As good practice, communication protocols should be versioned. In some cases, developers may want to radically change something such as the serialization format or the stable data layout of their canister. In radical changes like these, the stable memory decoding mechanism may need to guess the data's format, which can become messy and complicated. To make this process easier, stable memory versioning should be planned for. It can be as simple as declaring that the first byte of the canister's stable memory will be used to represent the version number. 
 

--- a/docs/samples/nft.md
+++ b/docs/samples/nft.md
@@ -33,9 +33,8 @@ The NFT canister example contains all those cases and shows how it can be done.
 Since the basic functions required in [DIP-721](https://github.com/Psychedelic/DIP721) are very straightforward to implement, this section only discusses how the above ideas are handled and implemented.
 
 ### Stable storage for canister upgrades
-During canister code upgrades, memory is not persisted between different canister calls. Only memory in stable memory is carried over.
-Because of that it is necessary to write all data to stable memory before the upgrade happens, which is usually done in the `pre_upgrade` function.
-This function is called by the system before the upgrade happens. After the upgrade, it is normal to load data from stable memory into memory
+During canister code upgrades, any data stored in a canister's heap storage is not persisted between different canister calls. Only memory in stable memory is carried over.
+Because of that it is necessary to write all data to stable memory before the upgrade happens. After the upgrade, it is normal to load data from stable memory into memory
 during the `post_upgrade` function. The `post_upgrade` function is called by the system after the upgrade happened.
 In case an error occurs during any part of the upgrade (including `post_upgdrade`), the entire upgrade is reverted.
 


### PR DESCRIPTION
This PR adds information about the current stable memory and heap storage limits, plus removes the recommendation to use a `pre_upgrade` hook when upgrading canisters. 

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [x] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [x] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
