### PR TITLE
Fix motoko-tutorial URL

### DIFF
--- a/docs/motoko/tutorial.mdx
+++ b/docs/motoko/tutorial.mdx
@@ -31,7 +31,7 @@ description: In the Motoko interactive tutorial, you will learn the basics of th
 
 <iframe
   id="course-iframe"
-  src="https://agorapp.dev/editor2/motoko/motoko-tutorial/introduction"
+  src="https://motoko.agorapp.dev/course/motoko/motoko-tutorial/introduction"
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
   allowfullscreen


### PR DESCRIPTION
Some time in the last two weeks our server where we host standalone Motoko Tutorial stopped working. We didn't have monitoring set up for it, so it took us a while before we noticed it. In the meantime someone has changed the URL to point to our main application.

Result is, that now there is our Login button visible and the editor has dark theme:

![CleanShot 2023-10-09 at 14 27 02](https://github.com/dfinity/portal/assets/373775/32483b2a-af76-4486-a283-e1995f39f398)

I have changed URL back to the original server. We have also added uptime monitoring to prevent this issue in the future. After this fix, tutorial page will look like this:

![CleanShot 2023-10-09 at 14 28 10](https://github.com/dfinity/portal/assets/373775/c5bc0e50-215b-4104-8189-7a0302ed5961)
