### PR TITLE
make whitepaper open on new tab

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,7 +127,10 @@ const marketingNav = {
         { name: "Video Library", href: "/videos" },
         // { name: "ICP on Youtube", href: "https://www.youtube.com/c/DFINITY" },
         { name: "ICP Wiki", href: "https://wiki.internetcomputer.org/" },
-        { name: "Whitepaper", href: "/whitepaper.pdf" },
+        {
+          name: "Whitepaper",
+          href: "https://internetcomputer.org/whitepaper.pdf",
+        },
         {
           name: "History of ICP",
           href: "https://wiki.internetcomputer.org/wiki/History",


### PR DESCRIPTION
React router catches the link click and throws 404. Make it open on a new tab to circumvent it.