### PR TITLE
chore: Fix some limit units

### DIFF
--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -16,7 +16,7 @@ The limits depend on the message type as shown in the following table.
 | Maximum cross-net inter-canister message payload                                     | 2MB        |
 | Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MB       |
 | Maximum response size                                                                | 2MB        |
-| Instruction limit, instructions per update call/heartbeat/timer                      | 20 bn       |
+| Instruction limit, instructions per update call/heartbeat/timer                      | 20 Billion       |
 | Instruction limit, instructions per query calls                                      | 5 bn        |
 | Instruction limit, instructions per canister install/upgrade                         | 200 Billion      |
 | Subnet capacity (total memory available per subnet)                                  | 700GiB     |

--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -18,7 +18,7 @@ The limits depend on the message type as shown in the following table.
 | Maximum response size                                                                | 2MB        |
 | Instruction limit, instructions per update call/heartbeat/timer                      | 20 bn       |
 | Instruction limit, instructions per query calls                                      | 5 bn        |
-| Instruction limit, instructions per canister install/upgrade                         | 200 bn      |
+| Instruction limit, instructions per canister install/upgrade                         | 200 Billion      |
 | Subnet capacity (total memory available per subnet)                                  | 700GiB     |
 | Wasm heap size, per canister                                                         | 4GiB       |
 | Wasm stable memory, per canister                                                     | 96GiB      |

--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -9,27 +9,27 @@ The limits depend on the message type as shown in the following table.
 
 ## Resource constraints and limits
 
-| Resource                                                                             | Constraint |
-| ------------------------------------------------------------------------------------ | ---------- |
-| Message queue limit, messages per canister                                           | 500        |
-| Maximum ingress message payload                                                      | 2MB        |
-| Maximum cross-net inter-canister message payload                                     | 2MB        |
-| Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MB       |
-| Maximum response size                                                                | 2MB        |
-| Instruction limit, instructions per update call/heartbeat/timer                      | 20 Billion       |
-| Instruction limit, instructions per query calls                                      | 5 Billion        |
-| Instruction limit, instructions per canister install/upgrade                         | 200 Billion      |
-| Subnet capacity (total memory available per subnet)                                  | 700GiB     |
-| Wasm heap size, per canister                                                         | 4GiB       |
-| Wasm stable memory, per canister                                                     | 96GiB      |
-| Wasm custom sections, per subnet                                                     | 2GiB       |
-| Wasm custom sections, per canister                                                   | 1MiB       |
-| Wasm custom sections, sections per canister                                          | 16         |
-| Wasm code section, per canister                                                      | 10MiB      |
-| Query calls execution threads, per replica node                                      | 4          |
-| Query calls execution threads, per canister                                          | 2          |
-| Update calls execution threads, per subnet                                           | 4          |
-| Update calls execution threads, per canister                                         | 1          |
+| Resource                                                                             | Constraint  |
+| ------------------------------------------------------------------------------------ | ----------- |
+| Message queue limit, messages per canister                                           | 500         |
+| Maximum ingress message payload                                                      | 2MB         |
+| Maximum cross-net inter-canister message payload                                     | 2MB         |
+| Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MB        |
+| Maximum response size                                                                | 2MB         |
+| Instruction limit, instructions per update call/heartbeat/timer                      | 20 Billion  |
+| Instruction limit, instructions per query calls                                      | 5 Billion   |
+| Instruction limit, instructions per canister install/upgrade                         | 200 Billion |
+| Subnet capacity (total memory available per subnet)                                  | 700GiB      |
+| Wasm heap size, per canister                                                         | 4GiB        |
+| Wasm stable memory, per canister                                                     | 96GiB       |
+| Wasm custom sections, per subnet                                                     | 2GiB        |
+| Wasm custom sections, per canister                                                   | 1MiB        |
+| Wasm custom sections, sections per canister                                          | 16          |
+| Wasm code section, per canister                                                      | 10MiB       |
+| Query calls execution threads, per replica node                                      | 4           |
+| Query calls execution threads, per canister                                          | 2           |
+| Update calls execution threads, per subnet                                           | 4           |
+| Update calls execution threads, per canister                                         | 1           |
 
 ## Additional notes
 

--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -17,7 +17,7 @@ The limits depend on the message type as shown in the following table.
 | Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MB       |
 | Maximum response size                                                                | 2MB        |
 | Instruction limit, instructions per update call/heartbeat/timer                      | 20 Billion       |
-| Instruction limit, instructions per query calls                                      | 5 bn        |
+| Instruction limit, instructions per query calls                                      | 5 Billion        |
 | Instruction limit, instructions per canister install/upgrade                         | 200 Billion      |
 | Subnet capacity (total memory available per subnet)                                  | 700GiB     |
 | Wasm heap size, per canister                                                         | 4GiB       |

--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -12,13 +12,13 @@ The limits depend on the message type as shown in the following table.
 | Resource                                                                             | Constraint |
 | ------------------------------------------------------------------------------------ | ---------- |
 | Message queue limit, messages per canister                                           | 500        |
-| Maximum ingress message payload                                                      | 2MiB       |
-| Maximum cross-net inter-canister message payload                                     | 2MiB       |
-| Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MiB      |
-| Maximum response size                                                                | 2MiB       |
-| Instruction limit, instructions per update call/heartbeat/timer                      | 20B        |
-| Instruction limit, instructions per query calls                                      | 5B         |
-| Instruction limit, instructions per canister install/upgrade                         | 200B       |
+| Maximum ingress message payload                                                      | 2MB        |
+| Maximum cross-net inter-canister message payload                                     | 2MB        |
+| Maximum same-subnet inter-canister message payload (may be deprecated at some point) | 10MB       |
+| Maximum response size                                                                | 2MB        |
+| Instruction limit, instructions per update call/heartbeat/timer                      | 20 bn       |
+| Instruction limit, instructions per query calls                                      | 5 bn        |
+| Instruction limit, instructions per canister install/upgrade                         | 200 bn      |
 | Subnet capacity (total memory available per subnet)                                  | 700GiB     |
 | Wasm heap size, per canister                                                         | 4GiB       |
 | Wasm stable memory, per canister                                                     | 96GiB      |


### PR DESCRIPTION
The payload limits are actually in megabytes, not mebibytes as the rest of the limits.

Also, use another abbreviation `bn` for billions instructions as `B` is easy to confuse with bytes.
