### PR TITLE
feat: specify instruction limit per inspect_message

### DIFF
--- a/docs/developer-docs/production/resource-limits.md
+++ b/docs/developer-docs/production/resource-limits.md
@@ -19,6 +19,7 @@ The limits depend on the message type as shown in the following table.
 | Instruction limit, instructions per update call/heartbeat/timer                      | 20 Billion  |
 | Instruction limit, instructions per query calls                                      | 5 Billion   |
 | Instruction limit, instructions per canister install/upgrade                         | 200 Billion |
+| Instruction limit, instructions per inspect_message                                  | 200 Million |
 | Subnet capacity (total memory available per subnet)                                  | 700GiB      |
 | Wasm heap size, per canister                                                         | 4GiB        |
 | Wasm stable memory, per canister                                                     | 96GiB       |


### PR DESCRIPTION
This PR adds separate instruction limits per `inspect_message` invocation introduced by a recent replica code MR (IC [commit](https://github.com/dfinity/ic/commit/d05aa4fc726427081c8f8bbf620d51ac8ea11f98)).