### PR TITLE
Removing trailing comma for Modclub entry which breaks json

### DIFF
--- a/showcase.json
+++ b/showcase.json
@@ -393,8 +393,9 @@
     "screenshots": [
       "/img/showcase/modclub_screenshot_0.webp"
     ],
-    "github": "https://github.com/modclub-app",
+    "github": "https://github.com/modclub-app"
   },
+  
   {
     "id": "querio",
     "name": "Querio",


### PR DESCRIPTION
Removing trailing comma for Modclub entry which breaks json

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
