### PR TITLE
Update deploying-your-first-bitcoin-dapp.md to use the right network types

### DIFF
--- a/docs/samples/deploying-your-first-bitcoin-dapp.md
+++ b/docs/samples/deploying-your-first-bitcoin-dapp.md
@@ -50,18 +50,18 @@ Deploying to the Internet Computer requires [cycles](../developer-docs/setup/cyc
 ### Deploy the smart contract to the Internet Computer
 
 ```bash
-dfx deploy --network=ic basic_bitcoin --argument '(variant { Testnet })'
+dfx deploy --network=ic basic_bitcoin --argument '(variant { testnet })'
 ```
 
 #### What this does
 - `dfx deploy` tells the command line interface to `deploy` the smart contract
 - `--network=ic` tells the command line to deploy the smart contract to the mainnet ICP blockchain
-- `--argument '(variant { Testnet })'` passes the argument `Testnet` to initialize the smart contract, telling it to connect to the Bitcoin testnet
+- `--argument '(variant { testnet })'` passes the argument `testnet` to initialize the smart contract, telling it to connect to the Bitcoin testnet
 
 :::info
-You're initializing the canister with `variant { Testnet }`, so that the canister connects to the the [Bitcoin testnet](https://en.bitcoin.it/wiki/Testnet). To be specific, this connects to `Testnet3`, which is the current Bitcoin test network used by the Bitcoin community. 
+You're initializing the canister with `variant { testnet }`, so that the canister connects to the the [Bitcoin testnet](https://en.bitcoin.it/wiki/Testnet). To be specific, this connects to `Testnet3`, which is the current Bitcoin test network used by the Bitcoin community. 
 
-To connect to the **Bitcoin mainnet**, one should use `variant { Mainnet }`
+To connect to the **Bitcoin mainnet**, one should use `variant { mainnet }`
 :::
 
 


### PR DESCRIPTION
If you run 
```
dfx deploy --network=ic basic_bitcoin --argument '(variant { Testnet })'
```
with the latest [btc example](https://github.com/dfinity/examples/tree/master/motoko/basic_bitcoin), you will get the below error:
![image](https://github.com/dfinity/portal/assets/118719397/afe48068-da83-4839-8ce7-f1b68c24c2e1)

The types are defined as lower-case at https://github.com/dfinity/examples/blob/master/motoko/basic_bitcoin/src/basic_bitcoin/src/Types.mo#L49 

After updating the command to use `testnet`, I can deploy the canister to IC mainnet successfully.
```
dfx deploy --network=ic basic_bitcoin --argument '(variant { testnet })'
```
