### PR TITLE
chore: node version 16 => 18

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
       - run: git submodule update --init
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install DFX
         uses: dfinity/setup-dfx@main


### PR DESCRIPTION
CI needs node 18+ now because of a new dev dependency.