### PR TITLE
Additions to EVM RPC canister documentation

### DIFF
--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -150,7 +150,7 @@ request : (
 
 Make sure to verify that RPC requests work as expected on the ICP mainnet! HTTP outcalls performed in the `request` method only reach consensus if the JSON-RPC response is the same each call. 
 
-If you encounter a consensus issue, [please let us know](https://github.com/dfinity/evm-rpc-canister) and we will look into whether it's possible to add official support for your use case. 
+If you encounter an issue with consensus, [please let us know](https://github.com/dfinity/evm-rpc-canister) and we will look into whether it's possible to add official support for your use case. 
 
 
 ### Registering your own provider

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -28,11 +28,11 @@ Other RPC methods (including those specific to non-Ethereum networks) may be acc
 
 The EVM RPC canister has built-in support for the following [Ethereum JSON-RPC providers](https://ethereum.org/developers/docs/apis/json-rpc):
 
-- [Alchemy](https://docs.alchemy.com/docs/how-to-read-data-with-json-rpc)
-- [Ankr](https://www.ankr.com/infrastructure/build-on-ethereum/)
-- [BlockPI](https://blockpi.io/)
-- [Cloudflare Web3](https://www.cloudflare.com/application-services/products/web3/)
-- [Public Node](https://www.publicnode.com/)
+- [Alchemy](https://docs.alchemy.com/docs/how-to-read-data-with-json-rpc): Ethereum mainnet, Sepolia testnet
+- [Ankr](https://www.ankr.com/infrastructure/build-on-ethereum/): Ethereum mainnet, Sepolia testnet
+- [BlockPI](https://blockpi.io/): Ethereum mainnet, Sepolia testnet
+- [Cloudflare Web3](https://www.cloudflare.com/application-services/products/web3/): Ethereum mainnet
+- [Public Node](https://www.publicnode.com/): Ethereum mainnet, Sepolia testnet
 
 Likewise, many of the providers on [ChainList.org](https://chainlist.org/) can be called using the canister's `request` method. 
 

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -1,25 +1,18 @@
 # EVM RPC canister
 
-To use the EVM RPC canister, you can import it into your project's `dfx.json` file:
+## Overview
 
-```json
-{
- "canisters": {
-   "evm_rpc": {
-     "type": "custom",
-     "candid": "https://github.com/internet-computer-protocol/ic-eth-rpc/releases/latest/download/evm_rpc.did",
-     "wasm": "https://github.com/internet-computer-protocol/ic-eth-rpc/releases/latest/download/evm_rpc_dev.wasm.gz",
-     "remote": {
-       "id": {
-         "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
-       }
-     }
-   }
- }
-}
-```
+**EVM RPC** is an Internet Computer canister smart contract for communicating with [Ethereum](https://ethereum.org/en/) and other [EVM blockchains](https://chainlist.org/?testnets=true) using an on-chain API. 
+
+This canister facilitates API requests to JSON-RPC services such as [CloudFlare](https://www.cloudflare.com/en-gb/web3/), [Alchemy](https://www.alchemy.com/), [Ankr](https://www.ankr.com/), [BlockPI](https://blockpi.io/), or [Public Node](https://www.publicnode.com/) using [HTTPS outcalls](https://internetcomputer.org/https-outcalls). This enables functionality similar to traditional Ethereum dApps, including querying Ethereum smart contract states and submitting raw transactions.
+
+Beyond the Ethereum blockchain, this canister also has partial support for Polygon, Avalanche, and other popular EVM networks. Check out [ChainList.org](https://chainlist.org/?testnets=true) for an extensive list of compatible networks and RPC providers.
+
+The source code for this project is available on GitHub ([dfinity/evm-rpc-canister](https://github.com/dfinity/evm-rpc-canister) ⭐️) under the Apache 2.0 license. 
 
 ## Supported RPC methods
+
+The following JSON-RPC methods are available as part of the canister's [Candid interface](https://github.com/dfinity/candid#readme):
 
 - `eth_feeHistory`: Queries the historical fee data to estimate gas prices for transactions.
 - `eth_getLogs`: Queries the logs of a specified block or transaction.
@@ -28,32 +21,116 @@ To use the EVM RPC canister, you can import it into your project's `dfx.json` fi
 - `eth_getTransactionReceipt`: Queries details about a submitted transaction.
 - `eth_sendRawTransaction`: Submits a signed transaction to the Ethereum network.
 
-Other JSON-RPC methods (including those specific to non-Ethereum networks) may be accessed using the canister's `request` method.
+Other RPC methods (including those specific to non-Ethereum networks) may be accessed using the canister's `request` method.
 
 
 ## Supported RPC providers
 
 The EVM RPC canister has built-in support for the following [Ethereum JSON-RPC providers](https://ethereum.org/developers/docs/apis/json-rpc):
 
-- Alchemy: `https://eth-mainnet.g.alchemy.com/v2/`
-- Ankr: `https://rpc.ankr.com/eth/`
-- BlockPI: `https://ethereum.blockpi.network/v1/rpc/`
-- Cloudflare Web3: `https://cloudflare-eth.com/v1/mainnet/`
-- Public Node: `https://ethereum.publicnode.com`
+- [Alchemy](https://docs.alchemy.com/docs/how-to-read-data-with-json-rpc)
+- [Ankr](https://www.ankr.com/infrastructure/build-on-ethereum/)
+- [BlockPI](https://blockpi.io/)
+- [Cloudflare Web3](https://www.cloudflare.com/application-services/products/web3/)
+- [Public Node](https://www.publicnode.com/)
 
-View the [full list of RPC providers for each EVM network.](https://chainlist.org/)
+Likewise, many of the providers on [ChainList.org](https://chainlist.org/) can be called using the canister's `request` method. 
+
+
+## Getting started
+
+To include the EVM RPC canister in a [dfx](https://internetcomputer.org/docs/current/references/cli-reference/dfx-parent) project, add the following to your `dfx.json` file:
+
+```json
+{
+  "canisters": {
+    "evm_rpc": {
+      "type": "custom",
+      "candid": "https://github.com/dfinity/evm-rpc-canister/releases/latest/download/evm_rpc.did",
+      "wasm": "https://github.com/dfinity/evm-rpc-canister/releases/latest/download/evm_rpc_dev.wasm.gz",
+      "remote": {
+        "id": {
+          "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
+        }
+      }
+    }
+  }
+}
+```
+
+Next, start the local replica and deploy the canister locally with a specified number of nodes (`13` for a standard ICP subnet):
+
+```
+dfx start --background
+dfx deploy evm_rpc --argument '(record { nodesInSubnet = 13 })'
+```
+
+Another option is to create a fork of the EVM RPC canister:
+
+```
+git clone https://github.com/dfinity/evm-rpc-canister
+```
+
+To deploy your own canister on the mainnet, run the `dfx deploy` command with the `--network ic` flag:
+
+```
+dfx deploy evm_rpc --network ic --argument '(record { nodesInSubnet = 13 })'
+```
+
+Note that when deploying your own canister, you may encounter API rate limits. Refer to the "Replacing API keys" section to learn how to configure API credentials.
+
+## Examples
+
+```bash
+# Configuration
+NETWORK=local
+IDENTITY=default
+CYCLES=1000000000
+WALLET=$(dfx identity get-wallet --network=$NETWORK --identity=$IDENTITY)
+RPC_SOURCE=EthMainnet
+JSON_RPC_SOURCE=Chain=1
+RPC_CONFIG=null
+
+# Get event logs for smart contract `0xdAC1...1ec7`
+dfx canister call evm_rpc eth_getLogs "(variant {$CANDID_SOURCE}, $RPC_CONFIG, record {addresses = vec {\"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}})" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Get the latest Ethereum block info
+dfx canister call evm_rpc eth_getBlockByNumber "(variant {$CANDID_SOURCE}, $RPC_CONFIG, variant {Latest})" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Get receipt for transaction `0xdd5d...4746f`
+dfx canister call evm_rpc eth_getTransactionReceipt "(variant {$CANDID_SOURCE}, $RPC_CONFIG, \"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f\")" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Get number of transactions for contract `0xdAC1...1ec7`
+dfx canister call evm_rpc eth_getTransactionCount "(variant {$CANDID_SOURCE}, $RPC_CONFIG, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Latest}})" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Get the fee history for the last 3 Ethereum blocks
+dfx canister call evm_rpc eth_feeHistory "(variant {$CANDID_SOURCE}, $RPC_CONFIG, record {blockCount = 3; newestBlock = variant {Latest}})" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Send a raw transaction
+dfx canister call evm_rpc eth_sendRawTransaction "(variant {$SOURCE}, $RPC_CONFIG, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" --with-cycles=$CYCLES --wallet=$WALLET
+
+# Send a raw JSON-RPC request
+dfx canister call evm_rpc request "(variant {$JSON_RPC_SOURCE}, "'"{ \"jsonrpc\": \"2.0\", \"method\": \"eth_gasPrice\", \"params\": [], \"id\": 1 }"'", 1000)" --with-cycles=$CYCLES --wallet=$WALLET
+```
+
 
 ### Custom JSON-RPC requests
 
 Send a raw JSON-RPC request to a custom URL with the `request` method:
 
+```bash
+dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 100000000 request '(variant {Custom={url = "https://ethereum.publicnode.com"}},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
-dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Custom={url = "https://ethereum.publicnode.com"}},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+
+To use a specific EVM chain, specify the chain's ID in the `Chain` variant:
+
+```
+dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 100000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 You can also specify an RPC provider using a specific EVM chain or RPC provider:
 
-```
+```candid
 type JsonRpcSource = variant {
   Chain : nat64;
   Provider : nat64;
@@ -69,339 +146,72 @@ request : (
 );
 ```
 
-Note that calling the `request` method may not reach HTTP outcall consensus depending on the provider. If you encounter a consensus issue, [please let us know](https://github.com/internet-computer-protocol/ic-eth-rpc) and we will look into whether it's possible to add official support for your use case. 
+## Caveats
+
+Make sure to verify that RPC requests work as expected on the ICP mainnet! HTTP outcalls performed in the `request` method only reach consensus if the JSON-RPC response is the same each call. 
+
+If you encounter a consensus issue, [please let us know](https://github.com/dfinity/evm-rpc-canister) and we will look into whether it's possible to add official support for your use case. 
+
 
 ### Registering your own provider
 
-To register your own RPC provider in your local replica, you can use the following command:
+To register your own RPC provider in your local replica, you can use the following commands:
 
-```
+```bash
+# Authorize your dfx identity to add an RPC provider
+OWNER_PRINCIPAL=$(dfx identity get-principal)
+dfx canister call evm_rpc authorize "(principal \"$OWNER_PRINCIPAL\", variant { RegisterProvider })"
+
+# Register a provider
 dfx canister call evm_rpc registerProvider '(record { chainId=1; hostname="cloudflare-eth.com"; credentialPath="/v1/mainnet"; cyclesPerCall=1000; cyclesPerMessageByte=100; })'
 ```
 
-In this command, the following configuration parameters are set:
+The `registerProvider` command has the following input parameters:
 
 - `chainId`: The ID of the blockchain network.
-- `baseUrl`: The JSON-RPC base URL. 
+- `hostname`: The JSON-RPC API hostname. 
 - `credentialPath`: The path to the RPC authentication.
 - `cyclesPerCall`: The amount of cycles charged per RPC call.
 - `cyclesPerMessageByte`: The amount of cycles charged per message byte. 
 
+## Replacing API keys
 
-Then, to authorize with this provider in your local environment, run the commands:
+If you want to add or change the API key in your local replica or a deployed fork of the canister, the first step is to determine the relevant `providerId` for the API.
 
-```
-PRINCIPAL=$(dfx identity get-principal)
-dfx canister call evm_rpc authorize "(principal \"$PRINCIPAL\", variant { RegisterProvider })"
-```
+Run the following command to view all registered providers:
 
-To deauthorize the provider locally, run the command:
-
-```
-dfx canister call evm_rpc deauthorize "(principal \"$PRINCIPAL\", variant { RegisterProvider })"
+```bash
+dfx canister call evm_rpc getProviders
 ```
 
-
-### Using a specific EVM chain
-
-To use a specific EVM chain, specify the chain's ID in the `Chain` variant:
+You should see a list of values. Look for the `providerId`, which in this case is `0`:
 
 ```
-dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
-```
-
-
-## Using the EVM RPC canister 
-
-To use include the EVM RPC canister in a dfx project, add the following to your `dfx.json` file:
-
-```
-{
-  "canisters": {
-    "evm_rpc": {
-      "type": "custom",
-      "candid": "https://github.com/internet-computer-protocol/ic-eth-rpc/releases/latest/download/evm_rpc.did",
-      "wasm": "https://github.com/internet-computer-protocol/ic-eth-rpc/releases/latest/download/evm_rpc_dev.wasm.gz",
-      "remote": {
-        "id": {
-          "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
-        }
-      }
-    }
+(
+  vec {
+    record {
+      cyclesPerCall = 0 : nat64;
+      owner = principal "k3uua-wskan-xmpt3-e5bpx-ibj67-azbop-s26l5-kaakn-64bvk-y4jlc-oqe";
+      hostname = "cloudflare-eth.com";
+      primary = false;
+      chainId = 1 : nat64;
+      cyclesPerMessageByte = 0 : nat64;
+      providerId = 0 : nat64;
+    };
   }
-}
+)
 ```
 
-Next, start the local replica and deploy the canister locally with 13 or 28 subnet nodes to simulate deployment on the mainnet:
+Update the configuration for an existing provider using the `updateProvider` method:
 
-```
-dfx start --background
-dfx deploy evm_rpc --argument '(record { nodesInSubnet = 13 })'
-```
-
-Another option is to create a fork of the EVM RPC canister:
-
-```
-git clone https://github.com/internet-computer-protocol/ic-eth-rpc
+```bash
+dfx canister call evm_rpc updateProvider '(record { providerId = 0; credentialPath = opt "/path/to/YOUR-API-KEY" })'
 ```
 
-To use the canister on the mainnet, deploy it with the `--network ic` flag:
+Note that `credentialPath` should include everything after the hostname. For example, an RPC provider with hostname `rpc.example.org` and credential path `/path/to/secret` will resolve to `https://rpc.example.org/path/to/secret`. 
 
+Some RPC services expect the API key in a request header instead of a URI path. In this case, use a command such as the following:
+
+```bash
+dfx canister call evm_rpc updateProvider '(record { providerId = 0; credentialHeaders = opt vec { record { name = "HEADER_NAME"; value = "HEADER_VALUE" } } })'
 ```
-dfx deploy evm_rpc --network ic --argument '(record { nodesInSubnet = 13 })'
-```
-
-## eth_gasPrice
-
-To query the current ETH gas price, make a call to the `eth_gasPrice` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Additional parameters; none are specified in this example.
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getLogs
-
-To query the logs of a specific transaction, make a call to the `eth_getLogs` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getLogs\",\"params\":[{\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\"]}],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies a 'topic' value. A topic is an array of 32 bytes of data. Additional parameters can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getlogs) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getBlockByNumber
-
-To query information about a block, make a call to the `eth_getBlockByNumber` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"0x1b4\", true],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies a block number, or the string "earliest", "latest," or "pending". Specifies a boolean of "true" or "false," where true returns the full transaction objects and false only returns the hashes of the transactions. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbynumber) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getTransactionReceipt
-
-To query a transaction receipt, make a call to the `eth_getTransactionReceipt` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionReceipt\",\"params\":[\"0x85d995eba9763907fdf35cd2034144dd9d53ce32cbec21349d4b12823c6860c5\"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the hash of a transaction. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbynumber) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_feeHistory
-
-To return a collection of historical gas information, make a call to the `eth_feeHistory` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_feeHistory\",\"params\":[\"4\",\"4\"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the number of blocks in the request range and the highest block of that requested range. Additional information can be found in the [JSON RPC documentation.](https://docs.alchemy.com/reference/eth-feehistory)
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-
-### eth_sendRawTransaction
-
-To submit a raw transaction, make a call to the `eth_sendRawTransaction` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_sendRawTransaction\",\"params\":[\"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675\"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the signed transaction data. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_sendrawtransaction) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getTransactionCount
-
-To return the amount of transactions sent from an address, make a call to the `eth_getTransactionCount` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x407d73d8a49eeb85d32cf465507dd71d507100c1\",\"latest\"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the address to query and the "latest", "earliest", or "pending" filter for transactions. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_gettransactioncount) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_call
-
-To execute a new message without creating a transaction (often used for read-only functions), make a call to the `eth_call` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_call) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getStorageAt
-
-To return the value of a storage position, make a call to the `eth_getStorageAt` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getStorageAt\",\"params\":["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "latest"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the contract address, integer of the position in the storage, and integer block number or string "latest", "earliest", or "pending" status. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getstorageat) 
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-
-### eth_estimateGas
-
-To estimate the gas fee, make a call to the `eth_estimateGas` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: All parameters are optional. Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_estimategas)
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-
-### eth_blockNumber
-
-To return the most recent block number, make a call to the `eth_blockNumber` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: No parameters.
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).
-
-### eth_getCode
-
-To return the code for an address, make a call to the `eth_getCode` JSON-RPC method:
-
-```
-dfx canister call evm_rpc --network ic request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getCode\",\"params\":[\"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\", \"0x2\"],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
-```
-
-In this request, the following configuration is passed:
-
-- `Url`: The URL of the RPC service. 
-- `jsonrpc`: The version of JSON-RPC used.
-- `method`: The RPC method being called.
-- `params`: Specifies the address and the integer block number of string "latest", "earliest", or "pending". Additional information can be found in the [JSON RPC documentation.](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getcode)
-- `id`: id of the request.
-
-Additionally, the flags used are:
-
-- `wallet`: The cycles wallet associated with the current dfx identity. 
-- `with-cycles`: The amount of cycles to send with the call. Sending cycles with the call is necessary to pay for the RPC call. Learn more about [RPC costs](overview.md).

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -33,6 +33,8 @@ Other JSON-RPC methods (including those specific to non-Ethereum networks) may b
 
 ## Supported RPC providers
 
+The EVM RPC canister has built-in support for the following [Ethereum JSON-RPC providers](https://ethereum.org/developers/docs/apis/json-rpc):
+
 - Alchemy: `https://eth-mainnet.g.alchemy.com/v2/`
 - Ankr: `https://rpc.ankr.com/eth/`
 - BlockPI: `https://ethereum.blockpi.network/v1/rpc/`
@@ -41,12 +43,12 @@ Other JSON-RPC methods (including those specific to non-Ethereum networks) may b
 
 View the [full list of RPC providers for each EVM network.](https://chainlist.org/)
 
-### Specifying an RPC provider
+### Custom JSON-RPC requests
 
-To specify the RPC provider you'd like to use, change the `Url` value:
+Send a raw request to a custom JSON-RPC API with the `request` method:
 
 ```
-dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Custom="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Custom={url = "https://ethereum.publicnode.com"}},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 You can also specify an RPC provider using a specific EVM chain or RPC provider:

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -46,15 +46,14 @@ View the [full list of RPC providers for each EVM network.](https://chainlist.or
 To specify the RPC provider you'd like to use, change the `Url` value:
 
 ```
-dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Url="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Custom="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
-You can also specify an RPC provider within your Candid file:
+You can also specify an RPC provider using a specific EVM chain or RPC provider:
 
 ```
 type JsonRpcSource = variant {
   Chain : nat64;
-  Service : record { hostname : text; chainId : opt nat64, headers: opt vec (text, text) };
   Provider : nat64;
   Custom : record { url : text; headers : vec (text, text) };
 };


### PR DESCRIPTION
Merges into https://github.com/dfinity/portal/pull/2404 with various additions to the EVM RPC documentation. 

Feel free to make changes directly in this PR, etc.

Also note that these changes anticipate the renaming of `internet-computer-protocol/ic-eth-rpc` to `dfinity/evm-rpc-canister`, which is currently in progress ([ITSM-506](https://dfinity.atlassian.net/servicedesk/customer/portal/22/ITSM-506?atlOrigin=eyJpIjoiNjc1Y2Q4MDViMzNiNDM2NTg5NGY5YmU0MmY0MDk0NDciLCJwIjoiaGFscC1zbGFjayJ9)).