### PR TITLE
Small adjustments to the 'What is IC' page

### DIFF
--- a/docs/concepts/what-is-ic.mdx
+++ b/docs/concepts/what-is-ic.mdx
@@ -1,6 +1,6 @@
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-# What is the Internet Computer?
+# Overview of ICP
 
 The Internet Computer Protocol (ICP) bridges the gap between traditional programming and blockchain-based development.
 Smart contracts on ICP are expressive and scalable like traditional apps, but benefit from the trustless and decentralized execution of a blockchain.
@@ -17,6 +17,7 @@ ICP is designed for a practical balance in the tradeoff between scalability and 
 
 In the conceptual diagram above, decentralization increases going from centralized servers to Ethereum, but that happens at the expense of scalability.
 ICP is located in the middle of this spectrum.
+The rest of this page walks through the core concepts and feature of ICP to show why that's the case.
 
 ## Subnets
 
@@ -25,9 +26,16 @@ ICP shards smart contracts over multiple instances of the blockchain.
 Each instance is called a **subnet** and has its own set of decentralized nodes running the consensus algorithm among themselves, building their own chain of blocks, and executing smart contracts.
 Each subnet runs in parallel with other subnets.
 A smart contract on one subnet can communicate with another smart contract on a different subnet through sending messages.
+Users can also send messages to smart contracts.
+The following diagram shows the flow of a message on ICP:
 
-A user interacts with a smart contract by sending a digitally signed message.
-The following diagram shows the flow of the message on ICP:
+<div class="text--center">
+  <img
+    src={useBaseUrl("/img/docs/icp-overview.png")}
+    alt="Flow of a message on ICP"
+    width="600"
+  />
+</div>
 
 1. The message goes to one of the boundary nodes (RPC nodes).
 1. The boundary node routes the message to the subnet that hosts the target smart contract.
@@ -37,14 +45,6 @@ The following diagram shows the flow of the message on ICP:
 
 Note that steps 3-5 are asynchronous and decoupled from each other, which may be unusual for developers who are used to Ethereum-style atomic transactions that are executed when they are added to a block.
 The motivation for this design is scalability.
-
-<div class="text--center">
-  <img
-    src={useBaseUrl("/img/docs/icp-overview.png")}
-    alt="Flow of a message on ICP"
-    width="600"
-  />
-</div>
 
 Subnets can have different sizes, i.e. replication factors, which determines the cost of running smart contracts on that subnet.
 It also impacts the time to finality and security.

--- a/sidebars.js
+++ b/sidebars.js
@@ -11,7 +11,7 @@ const sidebars = {
       items: [
         {
           type: "doc",
-          label: "What is the Internet Computer?",
+          label: "Overview of ICP",
           id: "concepts/what-is-ic",
         },
         {


### PR DESCRIPTION
- Change the title to "Overview of ICP" which better matches the contents. Another reason: "What is the Internet Computer?" is inconsistent with "Internet Computer Protocol" used in the text.
- Add a clarifying sentence at the end of introduction.
- Move the subnet diagram higher to split the text more evenly.