### PR TITLE
fix: spacing/sizing issues due to font size increase

### DIFF
--- a/src/components/DocsHome/AskAIWidget.tsx
+++ b/src/components/DocsHome/AskAIWidget.tsx
@@ -24,7 +24,7 @@ export function AskAIWidget() {
           />
         </Head>
         <button
-          className="ask-ai-widget-trigger invisible pointer-events-none docs:visible docs:pointer-events-auto button-white sm:button-fancy-ai sm:button-with-icon border-none transition-all sm:bg-[radial-gradient(67.52%_167.71%_at_50.38%_-41.67%,#EA2B7B_0%,#3B00B9_100%)] hover:text-white/80 stat-fade-in sm:button-small font-bold fixed sm:relative bottom-0 my-20 sm:my-0 flex rounded-full sm:rounded-xl h-12 w-12 sm:h-[unset] sm:w-[unset] items-center p-0 sm:px-3 sm:py-2"
+          className="ask-ai-widget-trigger invisible pointer-events-none docs:visible docs:pointer-events-auto button-white md:button-fancy-ai md:button-with-icon border-none transition-all md:bg-[radial-gradient(67.52%_167.71%_at_50.38%_-41.67%,#EA2B7B_0%,#3B00B9_100%)] hover:text-white/80 stat-fade-in md:button-small font-bold fixed md:relative bottom-0 my-20 md:my-0 flex rounded-full md:rounded-xl h-12 w-12 md:h-[unset] md:w-[unset] items-center p-0 md:px-3 md:py-2"
           style={{
             display: "flex",
             alignItems: "center",
@@ -34,7 +34,7 @@ export function AskAIWidget() {
           <span className={"flex-1 flex flex-col items-center"}>
             <BrainIcon className={"md:text-white"} />
           </span>
-          <span className={"hidden sm:block font-bold"}>Ask ICP.AI</span>
+          <span className={"hidden md:block font-bold"}>Ask ICP.AI</span>
         </button>
       </>
     )

--- a/src/components/DocsHome/index.tsx
+++ b/src/components/DocsHome/index.tsx
@@ -126,7 +126,7 @@ const DocsHomePage: FC = () => {
                 </p>
               </div>
             </div>
-          
+
             <div className="snap-center min-w-[80vw] sm:min-w-0 border-0 border-r sm:border-r-0 md:border-r sm:border-t md:border-t-0 border-solid border-black/10 px-6 sm:pl-8 sm:pr-0 md:px-6 pt-10 sm:pb-10 md:pb-0 md:pt-0 flex flex-col">
               <div className="mb-16 md:mb-0 md:h-[200px]">
                 <img
@@ -179,7 +179,7 @@ const DocsHomePage: FC = () => {
                 </p>
               </div>
             </div>
-            
+
             <div className="snap-center min-w-[80vw] sm:min-w-0 border-0 sm:border-t md:border-t-0 border-solid border-black/10 px-6 sm:pl-8 sm:pr-0 md:px-6 pt-10  md:pt-0 flex flex-col">
               <div className="mb-16 md:mb-0 md:h-[200px]">
                 <img
@@ -207,7 +207,7 @@ const DocsHomePage: FC = () => {
               </div>
             </div>
 
-            <div className="snap-center min-w-[80vw] sm:min-w-0 border-0 border-r sm:border-t md:border-t-0 border-solid border-black/10 px-6 sm:pl-0 sm:pr-8 md:px-6 pt-10 sm:pb-10 md:pb-0 md:pt-0 flex flex-col">
+            <div className="snap-center min-w-[80vw] sm:min-w-0  sm:border-r md:border-r-0 border-0 sm:border-t md:border-t-0 border-solid border-black/10 px-6 sm:pl-0 sm:pr-8 md:px-6 pt-10 sm:pb-10 md:pb-0 md:pt-0 flex flex-col">
               <div className="mb-16 md:mb-0 md:h-[200px]">
                 <img
                   src="/img/docs/solidity.png"
@@ -260,10 +260,10 @@ const DocsHomePage: FC = () => {
             </div>
             <div className="flex-1 flex flex-col">
               <p className="tw-paragraph text-black/80 mb-6 flex-1">
-                If you're a seasoned developer looking to deploy code on ICP, 
-                getting started is easy. Our developer Quick Start guides are designed 
-                to jumpstart your developer experience on the Internet Computer Protocol
-                using your preferred programming language.
+                If you're a seasoned developer looking to deploy code on ICP,
+                getting started is easy. Our developer Quick Start guides are
+                designed to jumpstart your developer experience on the Internet
+                Computer Protocol using your preferred programming language.
               </p>
               <p className="mb-0">
                 <Link

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -12,7 +12,6 @@
 :root {
   font-family: "CircularXX", sans-serif;
   --ifm-font-family-base: "CircularXX", sans-serif;
-  --ifm-font-size-base: 125%;
   --ifm-color-primary: #3b00b9;
   --ifm-color-primary-dark: #3500a7;
   --ifm-color-primary-darker: #32009d;
@@ -73,6 +72,7 @@ html.plugin-blog {
   --ifm-color-primary: #791e94;
   --ifm-navbar-link-hover-color: #791e94;
   --ifm-navbar-x-padding: 50px;
+  --ifm-font-size-base: 125%;
 
   @media (max-width: 996px) {
     --ifm-navbar-x-padding: var(--ifm-navbar-padding-horizontal);

--- a/src/theme/Logo/index.js
+++ b/src/theme/Logo/index.js
@@ -32,7 +32,7 @@ export default function Logo(props) {
     >
       {logo && (
         <div className={imageClassName}>
-          <img src={logo.src} alt={alt} className="!h-8 md:!h-10" />
+          <img src={logo.src} alt={alt} className="!h-[32px] md:!h-[40px]" />
         </div>
       )}
       {navbarTitle != null && <b className={titleClassName}>{navbarTitle}</b>}


### PR DESCRIPTION
Recent change https://github.com/dfinity/portal/pull/2439 to increase the font size introduced issues, because we use `rem` for sizing and spacing. Distances between and sizes of most non-text elements (eg cards, corners, borders, nav, images/logos) also increased by 25%, which broke the top flyout nav for instance.

This PR will:
* undo the 25% font size increase on the marketing pages, keeping it on the docs pages and the blog
* fix some layout and border issues on the docs pages in the list of programming languages
* fix the Ask AI button on small (ie tablet) screens on the docs pages
* fix the nav logo size to not depend on font size

