### PR TITLE
Update EVM RPC docs for custom Candid-RPC services

### DIFF
--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -125,7 +125,7 @@ dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 1000
 
 ## Specifying RPC services
 
-There are several ways to choose a specific JSON-RPC service:
+There are several ways to choose specific JSON-RPC services:
 
 ```candid
 // Used for "Candid-RPC" canister methods

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -125,7 +125,7 @@ dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 1000
 
 ## Specifying RPC services
 
-There are several ways to choose specific JSON-RPC services:
+There are several ways to use specific JSON-RPC services:
 
 ```candid
 // Used for Candid-RPC canister methods (`eth_getLogs`, `eth_getBlockByNumber`, etc.)
@@ -135,7 +135,7 @@ type RpcServices = variant {
   ...
   Custom : record {
     chainId : nat64;
-    services : vec record { url : text; headers : vec (text, text) };
+    services : vec record { url : text; headers : opt vec (text, text) };
   }
 };
 
@@ -146,8 +146,14 @@ type RpcService = variant {
   ...
   Chain : nat64;
   Provider : nat64;
-  Custom : record { url : text; headers : vec (text, text) };
+  Custom : record { url : text; headers : opt vec (text, text) };
 };
+```
+
+Here is an example command to submit an RPC request to the [Arbitrum](https://arbitrum.io/) L2 network:
+
+```bash
+dfx canister call evm_rpc eth_getBlockByNumber '(variant {Custom = record {chainId = 42161; services = vec {record {url = "https://1rpc.io/arb"}}}}, null, variant {Latest})' --with-cycles 10000000000 --wallet=$(dfx identity get-wallet)
 ```
 
 ## Registering your own provider

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -128,7 +128,7 @@ dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 1000
 There are several ways to choose specific JSON-RPC services:
 
 ```candid
-// Used for "Candid-RPC" canister methods
+// Used for Candid-RPC canister methods (`eth_getLogs`, `eth_getBlockByNumber`, etc.)
 type RpcServices = variant {
   EthMainnet : opt vec EthMainnetService;
   EthSepolia : opt vec EthSepoliaService;
@@ -139,7 +139,7 @@ type RpcServices = variant {
   }
 };
 
-// Used for the `request` method
+// Used for the JSON-RPC `request` canister method
 type RpcService = variant {
   EthMainnet : EthMainnetService;
   EthSepolia : EthSepoliaService;

--- a/docs/developer-docs/integrations/ethereum/evm-rpc.md
+++ b/docs/developer-docs/integrations/ethereum/evm-rpc.md
@@ -123,24 +123,31 @@ To use a specific EVM chain, specify the chain's ID in the `Chain` variant:
 dfx canister call evm_rpc --wallet $(dfx identity get-wallet) --with-cycles 100000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
-## Specifying an RPC provider
+## Specifying RPC services
 
-You can also specify an RPC provider:
+There are several ways to choose a specific JSON-RPC service:
 
 ```candid
-type JsonRpcSource = variant {
+// Used for "Candid-RPC" canister methods
+type RpcServices = variant {
+  EthMainnet : opt vec EthMainnetService;
+  EthSepolia : opt vec EthSepoliaService;
+  ...
+  Custom : record {
+    chainId : nat64;
+    services : vec record { url : text; headers : vec (text, text) };
+  }
+};
+
+// Used for the `request` method
+type RpcService = variant {
+  EthMainnet : EthMainnetService;
+  EthSepolia : EthSepoliaService;
+  ...
   Chain : nat64;
   Provider : nat64;
   Custom : record { url : text; headers : vec (text, text) };
 };
-
-request : (
-  source : JsonRpcSource,
-  jsonRequest : text,
-  maxResponseBytes : nat64
-) -> (
-  Result<text, RpcError>
-);
 ```
 
 ## Registering your own provider


### PR DESCRIPTION
This PR updates the EVM RPC canister documention to reflect changes introduced in https://github.com/internet-computer-protocol/evm-rpc-canister/pull/158. 

Currently set as a draft until we release the next version of the canister. 
