### PR TITLE
Update ETAs of roadmap items (in-progress and upcoming) to 2024

### DIFF
--- a/roadmap/1_core-protocol/in-progress/16_configurable_wasm_heap_limit.md
+++ b/roadmap/1_core-protocol/in-progress/16_configurable_wasm_heap_limit.md
@@ -3,7 +3,7 @@ title: Configurable Wasm Heap Limit
 links:
   Forum Link: https://forum.dfinity.org/t/proposal-configurable-wasm-heap-limit/17794
   Proposal: https://dashboard.internetcomputer.org/proposal/105322
-eta: 2023
+eta: 2024
 is_community: true
 ---
 

--- a/roadmap/1_core-protocol/upcoming/at-enc.md
+++ b/roadmap/1_core-protocol/upcoming/at-enc.md
@@ -3,7 +3,7 @@ title: Threshold Key Derivation
 links:
   Forum Link: https://forum.dfinity.org/t/threshold-key-derivation-privacy-on-the-ic/16560
   Proposal: 
-eta: 2023
+eta: 2024
 is_community: false
 ---
 

--- a/roadmap/3_system_utils_and_dapps/in-progress/02_cketh_tokens.md
+++ b/roadmap/3_system_utils_and_dapps/in-progress/02_cketh_tokens.md
@@ -2,7 +2,7 @@
 title: ckETH Token
 links:
   Forum Link: https://forum.dfinity.org/t/long-term-r-d-integration-with-the-ethereum-network/9382
-eta: 2023
+eta: 2024
 is_community: true
 ---
 

--- a/roadmap/5_developer_experience/in-progress/cycles_wallet_deprecation.md
+++ b/roadmap/5_developer_experience/in-progress/cycles_wallet_deprecation.md
@@ -3,7 +3,7 @@ title: Cycles Ledger
 links:
   Forum Post:
   Proposal:
-eta: Q4 23
+eta: 2024
 is_community: true
 ---
 

--- a/roadmap/5_developer_experience/in-progress/dfx_new.md
+++ b/roadmap/5_developer_experience/in-progress/dfx_new.md
@@ -3,7 +3,7 @@ title: Updates to the dfx new command
 links:
   Forum Post:
   Proposal:
-eta: Q4 2023
+eta: 2024
 is_community: false
 ---
 


### PR DESCRIPTION
While reading the roadmap, I found that some items (either in-progress or upcoming) were dated to be released with an ETA of 2023. So, I decided to fork, update and send a pull-request.

-----

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [x] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [x] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
