### PR TITLE
feat: add chips component for dev docs

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from "react";
+
+export interface ChipProps {
+  className?: string;
+  label?: string;
+  children?: ReactNode;
+}
+
+export function Chip({ label = "", children, className = "" }: ChipProps) {
+  return (
+    <div
+      className={`bg-infinite-60 text-white py-1 px-2 font-medium text-paragraph-sm rounded-full ${className}`.trim()}
+    >
+      {children ?? label}
+    </div>
+  );
+}

--- a/src/components/Chip/ChipRow.tsx
+++ b/src/components/Chip/ChipRow.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { ReactNode } from "react";
+
+export interface ChipRowProps {
+  children: ReactNode;
+}
+export function ChipRow(props: ChipRowProps) {
+  return <div className={"flex gap-2"}>{props.children}</div>
+}

--- a/src/components/Chip/ChipRow.tsx
+++ b/src/components/Chip/ChipRow.tsx
@@ -5,5 +5,5 @@ export interface ChipRowProps {
   children: ReactNode;
 }
 export function ChipRow(props: ChipRowProps) {
-  return <div className={"flex gap-2"}>{props.children}</div>
+  return <div className={"flex flex-wrap gap-2"}>{props.children}</div>
 }

--- a/src/components/Chip/MarkdownChipRow.tsx
+++ b/src/components/Chip/MarkdownChipRow.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Chip } from "@site/src/components/Chip/Chip";
+import { ChipRow } from "@site/src/components/Chip/ChipRow";
+
+export interface MarkdownChipRowProps {
+  labels: string[];
+}
+
+export function MarkdownChipRow(props: MarkdownChipRowProps) {
+  return (
+    <ChipRow>
+      {props.labels.map((label, index) => (
+        <Chip>{label}</Chip>
+      ))}
+    </ChipRow>
+  );
+}


### PR DESCRIPTION
I've provided a `MarkdownChipRow` component that exposes a simple interface for declaring multiple chips on a page. Just drop this component anywhere you want the chips to appear and provide an array of strings to use as the chip label.

Basic usage:

```mdx
import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";

# My Article Title

<MarkdownChipRow labels={["Beginner", "Intermediate"]} />

... article content ...
```

For more advanced usage, you can use `ChipRow` and `Chip` directly. For example, if you want to modify the color of the chip, you can override using the `className` prop:

```mdx
import { ChipRow } from "/src/components/Chip/ChipRow";
import { Chip } from "/src/components/Chip/Chip";

# My Article Title

<ChipRow>
  <Chip className="!bg-black">Black chip</Chip>
  <Chip>Purple chip</Chip>
</ChipRow>

... article content ...
```


![8fa7cbce5cba5adf3b63984619f70157](https://github.com/dfinity/portal/assets/98767015/bef13497-72cd-41e1-b10d-0312c8679f22)
