### PR TITLE
feat: add GlossaryTooltip component

### DIFF
--- a/docs/tests/all/GlossaryTooltip.test.mdx
+++ b/docs/tests/all/GlossaryTooltip.test.mdx
@@ -1,0 +1,25 @@
+---
+title: Glossary Tooltip Test
+description:
+  Testing integration of the GlossaryTooltip component in a markdown document
+draft: true
+---
+
+import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
+
+To add definitions to GlossaryTooltip, find the `glossary.txt` file in the
+`static` directory at the root of the project. Please make sure you put an `=`
+equal sign between the term and the definition, and keep each term + definition
+pair on a single line. Failing to do will break the code that autopopulates the
+Tooltip with the appropriate definition.
+
+Example
+```text
+canister=A smart contract on ICP.
+cycles=Currency unit used to pay for ICP gas fees.
+```
+
+I'm a <GlossaryTooltip>canister</GlossaryTooltip> deployed on
+ICP.
+
+I describe <GlossaryTooltip>cycles</GlossaryTooltip>.

--- a/src/components/Tooltip/GlossaryTooltip.tsx
+++ b/src/components/Tooltip/GlossaryTooltip.tsx
@@ -23,7 +23,17 @@ export function GlossaryTooltip(props: GlossaryTooltipProps) {
   }, []);
 
   const term = props.children;
-  const definition = glossary.get(term);
+
+  // even though we use typescript, a lot of content is MDX, which will
+  // still attempt to render the component with invalid props
+  if (!term || typeof term !== "string") {
+    console.warn(
+      "Attempted to render a tooltip with invalid content. Rendering null instead."
+    );
+    return null;
+  }
+
+  const definition = glossary.get(term.toLowerCase());
 
   if (definition) {
     return <Tooltip text={definition}>{props.children}</Tooltip>;

--- a/src/components/Tooltip/GlossaryTooltip.tsx
+++ b/src/components/Tooltip/GlossaryTooltip.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Tooltip } from "./Tooltip";
+
+export interface GlossaryTooltipProps {
+  children: string;
+}
+
+export function GlossaryTooltip(props: GlossaryTooltipProps) {
+  const [glossary, setGlossary] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    fetch("/glossary.txt")
+      .then((res) => res.text())
+      .then((glossary) => {
+        const lines = glossary.split("\n");
+        const map = new Map();
+        for (const line of lines) {
+          const [term, definition] = line.split("=");
+          map.set(term.trim().toLowerCase(), definition.trim());
+        }
+        setGlossary(map);
+      });
+  }, []);
+
+  const term = props.children;
+  const definition = glossary.get(term);
+
+  if (definition) {
+    return <Tooltip text={definition}>{props.children}</Tooltip>;
+  } else {
+    return props.children;
+  }
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -67,7 +67,7 @@ export function Tooltip({
     role,
   ]);
 
-  const tooltipColor = "rgba(24, 24, 24, 0.6)";
+  const tooltipColor = "rgba(24, 24, 24, 0.9)";
 
   return (
     <>

--- a/static/glossary.txt
+++ b/static/glossary.txt
@@ -1,0 +1,2 @@
+canister=A smart contract on ICP.
+cycles=Currency unit used to pay for ICP gas fees.


### PR DESCRIPTION
Adds a `GlossaryTooltip` component to automatically render Tooltips based on the word being wrapped by the component.

To add definitions to GlossaryTooltip, find the `glossary.txt` file in the
`static` directory at the root of the project. Please make sure you put an `=`
equal sign between the term and the definition, and keep each term + definition
pair on a single line. Failing to do will break the code that autopopulates the
Tooltip with the appropriate definition.