### PR TITLE
chore: optimize glossary tooltip

### DIFF
--- a/src/components/Tooltip/GlossaryTooltip.tsx
+++ b/src/components/Tooltip/GlossaryTooltip.tsx
@@ -1,26 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Tooltip } from "./Tooltip";
+import { useGlossary } from "@site/src/context/GlossaryProvider";
 
 export interface GlossaryTooltipProps {
   children: string;
 }
 
 export function GlossaryTooltip(props: GlossaryTooltipProps) {
-  const [glossary, setGlossary] = useState<Map<string, string>>(new Map());
-
-  useEffect(() => {
-    fetch("/glossary.txt")
-      .then((res) => res.text())
-      .then((glossary) => {
-        const lines = glossary.split("\n");
-        const map = new Map();
-        for (const line of lines) {
-          const [term, definition] = line.split("=");
-          map.set(term.trim().toLowerCase(), definition.trim());
-        }
-        setGlossary(map);
-      });
-  }, []);
+  const glossary = useGlossary();
 
   const term = props.children;
 

--- a/src/context/GlossaryProvider.tsx
+++ b/src/context/GlossaryProvider.tsx
@@ -1,0 +1,46 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+export interface GlossaryContext {
+  glossary: Map<string, string>;
+}
+
+export const glossaryContext = createContext<GlossaryContext>({
+  glossary: new Map(),
+});
+
+export const GlossaryProvider = (props: { children: ReactNode }) => {
+  const [glossary, setGlossary] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    fetch("/glossary.txt")
+      .then((res) => res.text())
+      .then((glossary) => {
+        const lines = glossary
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean);
+        const map = new Map();
+        for (const line of lines) {
+          const [term, definition] = line.split("=");
+          map.set(term.trim().toLowerCase(), definition.trim());
+        }
+        setGlossary(map);
+      });
+  }, []);
+
+  return (
+    <glossaryContext.Provider value={{ glossary }}>
+      {props.children}
+    </glossaryContext.Provider>
+  );
+};
+
+export function useGlossary() {
+  return useContext(glossaryContext).glossary;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,5 +1,6 @@
 import React from "react";
+import { GlossaryProvider } from "@site/src/context/GlossaryProvider";
 
 export default function Root({ children }) {
-  return <>{children}</>;
+  return <GlossaryProvider>{children}</GlossaryProvider>;
 }


### PR DESCRIPTION
Wrap the site root in `GlossaryProvider` so the glossary is only fetched once per page load.