### PR TITLE
Update candid-ui.mdx

### DIFF
--- a/docs/developer-docs/backend/motoko/candid-ui.mdx
+++ b/docs/developer-docs/backend/motoko/candid-ui.mdx
@@ -22,7 +22,7 @@ Based on the type signature of the actor, Candid also provides a web interface t
 
 To learn how to use Candid, check out the documentation here:
 
-- [Candid UI](/docs/current/developer-docs/smart-contracts/candid/index).
+- [Candid UI](/docs/current/developer-docs/smart-contracts/candid).
 
 - [What is Candid?](/docs/current/developer-docs/smart-contracts/candid/candid-concepts).
 


### PR DESCRIPTION
Fix typo in the link to the Candid UI - removed "/index" from the path end

Closes #2653
