### PR TITLE
style: react and juno icon size

### DIFF
--- a/src/components/DocsHome/index.tsx
+++ b/src/components/DocsHome/index.tsx
@@ -340,7 +340,7 @@ const DocsHomePage: FC = () => {
                 <img
                   src="/img/docs/react.svg"
                   alt="React quickstart"
-                  className="w-10 h-10"
+                  className="h-10"
                   loading="lazy"
                 />
               </div>
@@ -366,7 +366,7 @@ const DocsHomePage: FC = () => {
                 <img
                   src="/img/docs/juno.svg"
                   alt="Juno quickstart"
-                  className="w-10 h-10"
+                  className="h-10"
                   loading="lazy"
                 />
               </div>


### PR DESCRIPTION
On developers' [home](https://internetcomputer.org/docs/current/home), the React and Juno icons of the "Quickstart
Guides" do not inherits similar height as the other icons of the page. This PR fixes their height.

Reference "other" icons:

<img width="1536" alt="a" src="https://github.com/dfinity/portal/assets/16886711/3fde2534-898e-4025-bc58-58c0b6a1a14b">

Comparison with current size:

<img width="1536" alt="b" src="https://github.com/dfinity/portal/assets/16886711/41dc1e33-f869-4a31-a82f-b2dd4e4804cb">

Style improvement:

<img width="1536" alt="c" src="https://github.com/dfinity/portal/assets/16886711/88f1afda-8a68-40fb-93c6-e07d61830588">
