### PR TITLE
chore: fix syntax highlighting for motoko and candid

### DIFF
--- a/docs/developer-docs/getting-started/hello-world.mdx
+++ b/docs/developer-docs/getting-started/hello-world.mdx
@@ -182,12 +182,11 @@ Motoko is an Actor-based language and it represents the smart contract as an act
 
 This hello-world actor has a single function called greet. It is marked as query because it doesn't modify the state of the actor.  The function accepts a name as input and returns a greetings text.
 
-```motoko
-// src/hello_backend/main.mo
+```motoko title="src/hello_backend/main.mo"
 actor {
-public query func greet(name : Text) : async Text {
+  public query func greet(name : Text) : async Text {
     return "Hello, " # name # "!";
-};
+  };
 };
 ```
 
@@ -203,8 +202,7 @@ This Rust smart contract has a single function called greet. It is marked as que
 
 The function accepts a name as input and returns a greetings text.
 
-```rust
-// src/hello_backend/src/lib.rs
+```rust title="src/hello_backend/src/lib.rs"
 #[ic_cdk::query]
 fn greet(name: String) -> String {
     format!("Hello, {}!", name)
@@ -215,9 +213,7 @@ fn greet(name: String) -> String {
 
 <TabItem value="typescript" label="TypeScript">
 
-```typescript
-// src/hello_backend/src/index.ts
-
+```typescript title="src/hello_backend/src/index.ts"
 import { Canister, query, text } from 'azle';
 
 export default Canister({
@@ -233,9 +229,7 @@ export default Canister({
 
 Create the project directory and file structure:
 
-```python
-# src/hello_backend/src/main.py
-
+```python title="src/hello_backend/src/main.py"
 from kybra import query
 
 @query

--- a/docs/tests/all/Codeblock.test.mdx
+++ b/docs/tests/all/Codeblock.test.mdx
@@ -1,0 +1,32 @@
+---
+title: Codeblocks
+description: Testing integration of the Codeblock component in a markdown document
+draft: true
+---
+
+# Codeblocks & Syntax highlighting
+
+## Motoko
+```motoko title="src/hello_backend/main.mo" showLineNumbers
+actor {
+  public query func greet(name : Text) : async Text {
+    return "Hello, " # name # "!";
+  };
+};
+```
+
+## Rust
+```rust title="src/hello_backend/src/lib.rs" showLineNumbers
+#[ic_cdk::query]
+fn greet(name: String) -> String {
+    format!("Hello, {}!", name)
+}
+```
+
+## Candid
+```candid title="src/counter.did"
+service counter : {
+  // A method taking a reference to a function.
+  subscribe : (func (int) -> ()) -> ();
+}
+```

--- a/docs/tests/all/Tabs.test.mdx
+++ b/docs/tests/all/Tabs.test.mdx
@@ -1,8 +1,16 @@
+---
+title: Tabs Test
+description: Testing integration of the Tabs component in a markdown document
+draft: true
+---
+
 import TabItem from "@theme/TabItem";
 import { AdornedTabs } from "../../../src/components/Tabs/AdornedTabs";
 import { AdornedTab } from "../../../src/components/Tabs/AdornedTab";
 import { BetaChip } from "../../../src/components/Chip/BetaChip";
 import { Chip } from "../../../src/components/Chip/Chip";
+
+# Tabs
 
 The `AdornedTabs` component provides you with a mechanism to insert a start or
 end adornment to any of its `AdornedTab` children.

--- a/src/theme/CodeBlock/Content/String.js
+++ b/src/theme/CodeBlock/Content/String.js
@@ -1,9 +1,7 @@
-import React, { useState, useEffect } from "react";
-import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import React, { useMemo, useState } from "react";
 import String from "@theme-original/CodeBlock/Content/String";
 import Container from "@theme/CodeBlock/Container";
 import styles from "./styles.module.css";
-import hljs from "highlight.js/lib/core";
 import { extractConfig, handleRun } from "../hljs_run.js";
 import CopyButton from "@theme/CodeBlock/CopyButton";
 
@@ -43,105 +41,41 @@ function RunButton(props) {
   );
 }
 
-function ImmutableCodeBlock({ id, code, language, defaultCopy }) {
-  const ref = React.createRef();
-  useEffect(() => {
-    hljs.highlightElement(ref.current);
-  }, []);
-  return (
-    <Container as="div" className={styles.immutableCodeBlock}>
-      <pre id={id} className={language} ref={ref}>
-        <code>{code}</code>
-      </pre>
-      {/* defaultCopy is a flag for code (candid) with only copy button */}
-      {defaultCopy && (
-        <div className={styles.buttonGroup}>
-          <CopyButton className={styles.copyButton} code={code} />
-        </div>
-      )}
-    </Container>
-  );
-}
-
 export default function StringWrapper(props) {
-  if (props.className === "language-motoko" && ExecutionEnvironment.canUseDOM) {
-    if (props.hasOwnProperty("no-repl")) {
-      return (
-        <ImmutableCodeBlock
-          id={props.name}
-          code={props.children}
-          language="language-motoko"
-        />
-      );
-    }
-    const { useCodeJar } = require("react-codejar");
-    const [code, setCode] = useState(props.children || "");
-    const [output, setOutput] = useState("");
-    const [error, setError] = useState("");
-    const lineNumbers = props.children.split("\n").length > 3;
+  const [code, setCode] = useState(props.children || "");
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState("");
 
-    // syntax highlighting is done by CodeJar, creating new React components
-    const editorRef = useCodeJar({
-      code: code.replace(/^\s+|\s+$/g, ""), // trim newlines
-      onUpdate: (e) => {
-        setCode(e);
-      },
-      highlight: hljs.highlightElement,
-      lineNumbers
-    });
-    return (
-      <>
-        <Container as="div">
-          <div className={styles.codeBlockContent}>
-            <pre
-              id={props.name}
-              ref={editorRef}
-              className="language-motoko"
-              style={{ backgroundColor: "var(--prism-background-color)" }}
-            >
-              <code>{code}</code>
-            </pre>
-            <div className={styles.buttonGroup}>
-              <CopyButton className={styles.copyButton} code={code} />
-              <RunButton
-                code={code}
-                setOutput={setOutput}
-                setError={setError}
-                config={extractConfig(props)}
-              />
-            </div>
-          </div>
-        </Container>
-        {output || error ? (
-          <Container as="div">
-            {error ? <pre className="motoko-code-error">{error}</pre> : null}
-            {output ? (
-              <pre className="motoko-code-output">
-                <code>{output}</code>
-              </pre>
-            ) : null}
-          </Container>
-        ) : null}
-      </>
-    );
-  }
-  if (props.className === "language-candid" && ExecutionEnvironment.canUseDOM) {
-    // for candid code no run button is given
-    return (
-      <>
-        <ImmutableCodeBlock
-          code={props.children}
-          language="language-candid"
-          style={{ position: "relative" }}
-          defaultCopy={true}
-        />
-      </>
-    );
-  }
-  // default Docusaurus built-in String wrapper, leave as is
+  const showRunButton = useMemo(() => {
+    return props.className === "language-motoko";
+  }, [props.className]);
+
   return (
-    <div className={styles.defaultCodeBlock}>
-      <String {...props} />
+    <div style={{ position: "relative" }}>
+      <Container as="div">
+        {showRunButton && (
+          <div className={styles.buttonGroup}>
+            <CopyButton className={styles.copyButton} code={code} />
+            <RunButton
+              code={code}
+              setOutput={setOutput}
+              setError={setError}
+              config={extractConfig(props)}
+            />
+          </div>
+        )}
+        <String {...props} />
+      </Container>
+      {(output || error) && showRunButton ? (
+        <Container as="div">
+          {error ? <pre className="motoko-code-error">{error}</pre> : null}
+          {output ? (
+            <pre className="motoko-code-output">
+              <code>{output}</code>
+            </pre>
+          ) : null}
+        </Container>
+      ) : null}
     </div>
   );
 }

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -98,7 +98,8 @@
   background-color: #242834;
   border-radius: var(--ifm-global-radius);
   transition: opacity 200ms ease-in-out;
-  opacity: 0;
+  opacity: 1;
+  z-index: 1;
 }
 .defaultCodeBlock div[class*="buttonGroup_"] button,
 .buttonGroup button {

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,24 @@
+import siteConfig from "@generated/docusaurus.config";
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  // add support for Motoko syntax highlighting
+  require("./prism/prism-motoko");
+  require("./prism/prism-candid");
+
+  delete globalThis.Prism;
+}

--- a/src/theme/prism/prism-candid.js
+++ b/src/theme/prism/prism-candid.js
@@ -1,0 +1,19 @@
+Prism.languages.candid = Prism.languages.extend('clike', {
+  'string': {
+    pattern: /(^|[^\\])"(?:\\.|[^"\\\r\n])*"|`[^`]*`/,
+    lookbehind: true,
+    greedy: true
+  },
+  'keyword': /\b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|actor|func|go(?:to)?|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/,
+  'boolean': /\b(?:_|false|iota|nil|true)\b/,
+  'number': [
+    // binary and octal integers
+    /\b0(?:b[01_]+|o[0-7_]+)i?\b/i,
+    // hexadecimal integers and floats
+    /\b0x(?:[a-f\d_]+(?:\.[a-f\d_]*)?|\.[a-f\d_]+)(?:p[+-]?\d+(?:_\d+)*)?i?(?!\w)/i,
+    // decimal integers and floats
+    /(?:\b\d[\d_]*(?:\.[\d_]*)?|\B\.\d[\d_]*)(?:e[+-]?[\d_]+)?i?(?!\w)/i
+  ],
+  'operator': /[*\/%^!=]=?|\+[=+]?|-[=-]?|\|[=|]?|&(?:=|&|\^=?)?|>(?:>=?|=)?|<(?:<=?|=|-)?|:=|\.\.\./,
+  'builtin': /\b(?:query|public|async|cap|close|complex|complex(?:64|128)|copy|delete|error|float(?:32|64)|u?int(?:8|16|32|64)?|imag|len|make|new|panic|print(?:ln)?|real|recover|rune|string|uintptr)\b/
+});

--- a/src/theme/prism/prism-motoko.js
+++ b/src/theme/prism/prism-motoko.js
@@ -1,0 +1,19 @@
+Prism.languages.motoko = Prism.languages.extend('clike', {
+  'string': {
+    pattern: /(^|[^\\])"(?:\\.|[^"\\\r\n])*"|`[^`]*`/,
+    lookbehind: true,
+    greedy: true
+  },
+  'keyword': /\b(?:break|case|chan|const|continue|default|defer|else|fallthrough|for|actor|func|go(?:to)?|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/,
+  'boolean': /\b(?:_|false|iota|nil|true)\b/,
+  'number': [
+    // binary and octal integers
+    /\b0(?:b[01_]+|o[0-7_]+)i?\b/i,
+    // hexadecimal integers and floats
+    /\b0x(?:[a-f\d_]+(?:\.[a-f\d_]*)?|\.[a-f\d_]+)(?:p[+-]?\d+(?:_\d+)*)?i?(?!\w)/i,
+    // decimal integers and floats
+    /(?:\b\d[\d_]*(?:\.[\d_]*)?|\B\.\d[\d_]*)(?:e[+-]?[\d_]+)?i?(?!\w)/i
+  ],
+  'operator': /[*\/%^!=]=?|\+[=+]?|-[=-]?|\|[=|]?|&(?:=|&|\^=?)?|>(?:>=?|=)?|<(?:<=?|=|-)?|:=|\.\.\./,
+  'builtin': /\b(?:query|public|async|cap|close|complex|complex(?:64|128)|copy|delete|error|float(?:32|64)|u?int(?:8|16|32|64)?|imag|len|make|new|panic|print(?:ln)?|real|recover|rune|string|uintptr)\b/
+});


### PR DESCRIPTION
Syntax highlighting wasn't working for Motoko or Candid. This PR simplifies how Motoko and Candid code is rendered, using as much built-in capability provided by Docusaurus as possible.

This also introduces two new grammar files for [Prism](https://github.com/PrismJS/prism/tree/master/components) - `prism-motoko.js` and `prism-candid.js`.

Both of these are based on the `prism-go.js` file and extend the "c-like" grammar. @rvanasa or @chenyan-dfinity I could use your help updating `prism-motoko.js` and `prism-candid.js` with the most accurate grammar definition.

![image](https://github.com/dfinity/portal/assets/98767015/7b6e0efc-6062-412c-b11a-b25d27b12bd7)
