### PR TITLE
chore: disable automatic line break insertion

### DIFF
--- a/plugins/howitworks-articles.js
+++ b/plugins/howitworks-articles.js
@@ -61,7 +61,7 @@ const howItWorksArticlesPlugin = async function () {
                 abstract: meta.data.abstract,
                 shareImage: meta.data.shareImage,
                 slug: meta.data.slug,
-                content: marked.parse(meta.content, { renderer }),
+                content: marked.parse(meta.content, { renderer, breaks: false }),
                 fileName: path.join("./how-it-works/", dir.name, sp.name),
               };
             })

--- a/plugins/howitworks-articles.js
+++ b/plugins/howitworks-articles.js
@@ -61,7 +61,10 @@ const howItWorksArticlesPlugin = async function () {
                 abstract: meta.data.abstract,
                 shareImage: meta.data.shareImage,
                 slug: meta.data.slug,
-                content: marked.parse(meta.content, { renderer, breaks: false }),
+                content: marked.parse(meta.content, {
+                  renderer,
+                  breaks: false,
+                }),
                 fileName: path.join("./how-it-works/", dir.name, sp.name),
               };
             })


### PR DESCRIPTION
The `howitworks-articles` plugin was inserting line breaks automatically. This PR disables that behavior.