### PR TITLE
clarify location of .well-known and ic-domains

### DIFF
--- a/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
+++ b/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
@@ -67,9 +67,13 @@ For non-apex (e.g. www), the name should be the standard “_canister-id.www” 
 
 --------------------------------------
 
-- #### Step 2: Create a file named `ic-domains` in your canister under `.well-known` containing the custom domain.
+- #### Step 2: Create a file named `ic-domains` in your canister under the `.well-known` directory containing the custom domain.
+
+The `.well-known` directory with the `ic-domains` file should be placed within the canister files, not at the root. The location of the files should allow your frontend framework to include the files during the build process. 
+
 By default, `dfx` excludes all files and directories whose names start with a `.` from the asset canister. Hence, to include the `ic-domains`-file, you need to create an additional file, called `.ic-assets.json`.
-Create a new file with the name `.ic-assets.json` inside a directory listed in `source` in `dfx.json`.
+
+Create a new file with the name `.ic-assets.json` inside the same top-level directory as the `.well-known` directory.
 
 To use multiple custom domains and their subdomains with a single canister, simply list each one of them on a newline in the `ic-domains`-file:
 ```sh


### PR DESCRIPTION
As per the conversation of [this thread](https://forum.dfinity.org/t/aws-domain-to-a-webpage-canister/28085/10?u=jennifertran), the developer requested to clarify the location of the `.well-known` directory and `ic-domains` file. 

Thank you for your contribution to the IC Developer Portal.
Before submitting your Pull Request, please make sure that:

- [ ] You have updated the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file according to your changes.
- [ ] You have registered new documents to [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js) if any.
