### PR TITLE
feat: add canister locking example with generic types to security best practices

### DIFF
--- a/docs/developer-docs/security/_attachments/lock.rs
+++ b/docs/developer-docs/security/_attachments/lock.rs
@@ -16,6 +16,7 @@ impl<T: Ord> Default for State<T> {
 }
 
 pub struct CallerGuard<T: Ord> {
+    /// We use `Rc` and `RefCell` here as we need both multiple owners (every lock is an owner) and mutable borrows for the state (updating the state after releasing the lock).
     state: Rc<RefCell<State<T>>>,
     lock: T,
 }

--- a/docs/developer-docs/security/_attachments/lock.rs
+++ b/docs/developer-docs/security/_attachments/lock.rs
@@ -1,0 +1,40 @@
+use std::cell::RefCell;
+use std::cmp::Ord;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+
+pub struct State<T: Ord> {
+    pending_requests: BTreeSet<T>,
+}
+
+impl<T: Ord> Default for State<T> {
+    fn default() -> Self {
+        Self {
+            pending_requests: BTreeSet::new(),
+        }
+    }
+}
+
+pub struct CallerGuard<T: Ord> {
+    state: Rc<RefCell<State<T>>>,
+    lock: T,
+}
+
+impl<T: Clone + Ord> CallerGuard<T> {
+    pub fn new(state: Rc<RefCell<State<T>>>, lock: T) -> Option<Self> {
+        {
+            let pending_requests = &mut state.borrow_mut().pending_requests;
+            if pending_requests.contains(&lock) {
+                return None;
+            }
+            pending_requests.insert(lock.clone());
+        }
+        Some(Self { state, lock })
+    }
+}
+
+impl<T: Ord> Drop for CallerGuard<T> {
+    fn drop(&mut self) {
+        self.state.borrow_mut().pending_requests.remove(&self.lock);
+    }
+}

--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.mdx
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.mdx
@@ -401,7 +401,7 @@ This pattern can be extended e.g. to work for the following use cases:
 - A global lock that does not only lock per caller. For this, set a boolean flag in the canister state instead of using a `BTreeSet<Principal>`.
 - A guard that makes sure that only a limited number of principals are allowed to execute a method at the same time. For this, one can return an error in `CallerGuard::new()` in case `pending_requests.len() >= MAX_NUM_CONCURRENT_REQUESTS`.
 - A guard that limits the number of times a method can be called in parallel. For this, use a counter in the canister state that is checked and increased in `CallerGuard::new()` and decreased in `Drop`.
-- A lock that uses a different type than `Principal` to grant access to the resource. You can find an implementation using generic types [here](./_attachments/lock.rs).
+- A lock that uses a different type than `Principal` to grant access to the resource. [View an implementation using generic types](./_attachments/lock.rs).
 
 Finally, note that the same guard can be used in several methods to restrict parallel execution of them.
 

--- a/docs/developer-docs/security/rust-canister-development-security-best-practices.mdx
+++ b/docs/developer-docs/security/rust-canister-development-security-best-practices.mdx
@@ -401,6 +401,7 @@ This pattern can be extended e.g. to work for the following use cases:
 - A global lock that does not only lock per caller. For this, set a boolean flag in the canister state instead of using a `BTreeSet<Principal>`.
 - A guard that makes sure that only a limited number of principals are allowed to execute a method at the same time. For this, one can return an error in `CallerGuard::new()` in case `pending_requests.len() >= MAX_NUM_CONCURRENT_REQUESTS`.
 - A guard that limits the number of times a method can be called in parallel. For this, use a counter in the canister state that is checked and increased in `CallerGuard::new()` and decreased in `Drop`.
+- A lock that uses a different type than `Principal` to grant access to the resource. You can find an implementation using generic types [here](./_attachments/lock.rs).
 
 Finally, note that the same guard can be used in several methods to restrict parallel execution of them.
 


### PR DESCRIPTION
This PR adds a canister locking example with generic types to security best practices. The example has been taken from the orbit-wallet ([link](https://github.com/dfinity/orbit-wallet/blob/9a9bba61213edf2e461fdd2f548ab34ade89233d/libs/ic-canister-core/src/utils/lock.rs)).