### PR TITLE
feat(RUN-971): Add page listing Execution errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,6 @@ docs/developer-docs/build/agents @dfinity/dx
 docs/developer-docs/build/cdks @dfinity/dx
 docs/developer-docs/integrations/rosetta @dfinity/finint
 docs/developer-docs/security @dfinity/product-security
+docs/references/execution-errors.mdx @dfinity/runtime @dfinity/execution
 
 # Each piece of documentation must be owned by the respective teams

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -1,6 +1,6 @@
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
-# Execution Errors
+# Execution errors
 
 <MarkdownChipRow labels={["Reference"]} />
 

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -21,6 +21,6 @@ To fix this error, consider:
 
 - Checking that the method name exactly matches the name exported by the callee.
 - Checking that the method type (update, query, etc...) is the same as the type of the exported method.
-- The canister code of the callee has not been modified to a version that depricates the method.
+- The canister code of the callee has not been modified to a version that deprecates the method.
 
 For further information on calling canisters see the [smart contract docs](../developer-docs/smart-contracts/call/overview) and the [IC spec](./ic-interface-spec#system-api-requests).

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -19,8 +19,8 @@ An example of this error is:
 
 To fix this error, consider:
 
-1. Checking that the method name exacly matches the name exported by the callee.
-1. Checking that the method type (update, query, etc...) is the same as the type of the exported method.
-1. The canister code of the callee has not been modified to a version that depricates the method.
+- Checking that the method name exactly matches the name exported by the callee.
+- Checking that the method type (update, query, etc...) is the same as the type of the exported method.
+- The canister code of the callee has not been modified to a version that depricates the method.
 
 For further information on calling canisters see the [smart contract docs](../developer-docs/smart-contracts/call/overview) and the [IC spec](./ic-interface-spec#system-api-requests).

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -9,7 +9,7 @@ A list of possible errors returned when executing canisters.
 
 ## Errors
 
-### Method Not found
+### Method not found
 A canister was called with a method name not exported by that canister.
 
 An example of this error is:

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -1,0 +1,26 @@
+import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
+
+# Execution Errors
+
+<MarkdownChipRow labels={["Reference"]} />
+
+## Overview
+A list of possible errors returned when executing canisters.
+
+## Errors
+
+### Method Not found
+A canister was called with a method name not exported by that canister.
+
+An example of this error is:
+```
+  Error from Canister xxx-xxx: Canister has no update method 'foobar'.
+```
+
+To fix this error, consider
+
+1. Checking that the method name exacly matches the name exported by the callee.
+1. Checking that the method type (update, query, etc...) is the same as the type of the exported method.
+1. The canister code of the callee has not been modified to a version that depricates the method.
+
+For further information on calling canisters see the [smart contract docs](../developer-docs/smart-contracts/call/overview) and the [IC spec](./ic-interface-spec#system-api-requests).

--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -17,7 +17,7 @@ An example of this error is:
   Error from Canister xxx-xxx: Canister has no update method 'foobar'.
 ```
 
-To fix this error, consider
+To fix this error, consider:
 
 1. Checking that the method name exacly matches the name exported by the callee.
 1. Checking that the method type (update, query, etc...) is the same as the type of the exported method.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1170,6 +1170,11 @@ const sidebars = {
             "developer-docs/multi-chain/faq/signatures-faq",
           ],
         },
+        {
+          type: "doc",
+          label: "Execution errors",
+          id: "references/execution-errors",
+        },
       ],
     },
   ],


### PR DESCRIPTION
Add a doc page which will be filled in with information about various
execution errors. Links to this page will be provided with each errors
returned by ICP.