### PR TITLE
Update ManageLedgerParameters docs

### DIFF
--- a/docs/developer-docs/daos/sns/managing/making-proposals.mdx
+++ b/docs/developer-docs/daos/sns/managing/making-proposals.mdx
@@ -603,7 +603,7 @@ quill send message.json
 
 ### `ManageLedgerParameters`
 The proposal `ManageLedgerParameters` can be used to update some of the SNS ledger canister's parameters.
-For now, the only ledger parameters that can be changed is the transfer fee, token symbol, token name, and token logo.
+The ledger parameters that can be changed are the transfer fee, the token symbol, the token name, and the token logo.
 Later, additional paramters might be added.
 Fields where a value is set to `None` will remain unchanged.
 

--- a/docs/developer-docs/daos/sns/managing/making-proposals.mdx
+++ b/docs/developer-docs/daos/sns/managing/making-proposals.mdx
@@ -618,7 +618,7 @@ type ManageLedgerParameters = record {
 };
 ```
 
-Example in bash (only change the transfer fee):
+Example in bash that only changes the transfer fee:
 
 ```bash
 quill sns make-proposal <PROPOSER_NEURON_ID> --proposal '(

--- a/docs/developer-docs/daos/sns/managing/making-proposals.mdx
+++ b/docs/developer-docs/daos/sns/managing/making-proposals.mdx
@@ -603,19 +603,22 @@ quill send message.json
 
 ### `ManageLedgerParameters`
 The proposal `ManageLedgerParameters` can be used to update some of the SNS ledger canister's parameters.
-For now, the only ledger parameter that can be changed is the transfer fee.
+For now, the only ledger parameters that can be changed is the transfer fee, token symbol, token name, and token logo.
 Later, additional paramters might be added.
 Fields where a value is set to `None` will remain unchanged.
 
 #### Relevant type signatures
 
 ```candid
-  type ManageLedgerParameters = record {
-    transfer_fee : opt nat64
-  };
+type ManageLedgerParameters = record {
+  token_symbol : opt text;
+  transfer_fee : opt nat64;
+  token_logo : opt text;
+  token_name : opt text;
+};
 ```
 
-Example in bash:
+Example in bash (only change the transfer fee):
 
 ```bash
 quill sns make-proposal <PROPOSER_NEURON_ID> --proposal '(


### PR DESCRIPTION
We added new functionality to ManageLedgerParameters. This PR doesn't change the docs to specify how to use it, but it does at least change them to not lie about its nonexistence like the previous version did