### PR TITLE
chore: use icx-asset for preview deployments

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.ref }}
+      group: pr-${{ github.event.pull_request.number || github.event.number }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -81,7 +81,7 @@ jobs:
 
           dfx canister --network ic create --all
           dfx build --network ic portal
-          dfx canister --network ic install portal --wasm .dfx/ic/canisters/portal/assetstorage.wasm.gz
+          dfx canister --network ic install portal --wasm .dfx/ic/canisters/portal/assetstorage.wasm.gz || true
 
           icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
 

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install icx-asset
         if: steps.cache-icx-asset-bin.outputs.cache-hit != 'true'
         run: |
+          # icx-asset improved sync performance: https://github.com/dfinity/sdk/pull/3766
           git clone -b akos/asset-upload-strategies --single-branch https://github.com/dfinity/sdk.git
           cd sdk
           cargo build -p icx-asset --release
@@ -75,15 +76,15 @@ jobs:
 
           # install and deploy
           git submodule update --init
-          npm install
+          time npm install
 
           export PREVIEW_CANISTER_ID=$canister_id
 
           dfx canister --network ic create --all
-          dfx build --network ic portal
+          time dfx build --network ic portal
           dfx canister --network ic install portal --wasm .dfx/ic/canisters/portal/assetstorage.wasm.gz || true
 
-          icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
+          time icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
 
         env:
           DFX_IDENTITY_PREVIEW: ${{ secrets.DFX_IDENTITY_PREVIEW }}

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -82,6 +82,8 @@ jobs:
           dfx canister create --all
           dfx canister install $(dfx canister id portal) --wasm .dfx/local/canisters/frontend/assetstorage.wasm.gz
 
+          npm run build
+
           icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
 
         env:

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -79,10 +79,9 @@ jobs:
 
           export PREVIEW_CANISTER_ID=$canister_id
 
-          dfx canister create --all
-          dfx canister install $(dfx canister id portal) --wasm .dfx/local/canisters/frontend/assetstorage.wasm.gz
-
-          npm run build
+          dfx canister --network ic create --all
+          dfx build --network ic portal
+          dfx canister --network ic install portal --wasm .dfx/ic/canisters/portal/assetstorage.wasm.gz
 
           icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
 

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.ref }}
+      group: pr-${{ github.event.pull_request.number || github.event.number }}
       cancel-in-progress: true
 
     steps:
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - uses: actions/github-script@v6
         with:
           script: |
@@ -36,22 +36,33 @@ jobs:
       - name: Install DFX
         uses: dfinity/setup-dfx@main
 
+      - name: Cache icx-asset binary
+        id: cache-icx-asset-bin
+        uses: actions/cache@v3
+        with:
+          path: sdk/target/debug/dfx
+          key: icxassetbin-19e18d1560aafedb3ab9764932755fd649be920a
+          restore-keys: |
+            - icxassetbin-
+
+      - name: Install icx-asset
+        if: steps.cache-icx-asset-bin.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/dfinity/sdk.git --single-branch
+          cd sdk
+          git checkout cce6ae0a2aeaee015612d49ce93047342e9fb4ec
+          cargo build -p icx-asset --release
+
+      - name: Add icx-asset to path
+        run: |
+          echo "`pwd`/sdk/target/release/" >> $GITHUB_PATH
+
       - name: "Build & Deploy"
         run: |
           mkdir -p ~/.config/dfx/identity/default
 
           echo $DFX_IDENTITY_PREVIEW | base64 -d > ~/.config/dfx/identity/default/identity.pem
           sed -i 's/\\r\\n/\r\n/g' ~/.config/dfx/identity/default/identity.pem
-
-          # check pool canister balance and send notification if it's under 5TC
-          balance=$(dfx canister --network ic status $POOL_CANISTER_ID 2>&1 >/dev/null | grep Balance: | sed 's/[^0-9]//g')
-          LANG=en_US.UTF-8
-          balance_formatted=$(echo $balance | awk '{printf "%'\''d\n", $0}')
-          echo "Pool balance: $balance_formatted"
-          if [ "5000000000000" -gt "$balance" ]; then
-            template="{ \"channel\": \"C04EGHHU9U2\", \"blocks\": [ { \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"@channel Preview pool canister \`$POOL_CANISTER_ID\` balance is \`$balance_formatted\`.\n\nTop it up by\n- running \`dfx ledger --network ic top-up $POOL_CANISTER_ID --amount 5.0\`\n- or by adding the canister on the NNS and sending cycles to it.\" } } ]}"
-            curl --data "$template" -H "Content-type: application/json"  -H "Authorization: Bearer $SLACK_TOKEN" -X POST https://slack.com/api/chat.postMessage -o /dev/null
-          fi
 
           # request preview canister from the pool
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -69,7 +80,10 @@ jobs:
 
           export PREVIEW_CANISTER_ID=$canister_id
 
-          dfx deploy --network=ic --no-wallet portal --yes
+          dfx canister create --all
+          dfx canister install $(dfx canister id portal) --wasm .dfx/local/canisters/frontend/assetstorage.wasm.gz
+
+          icx-asset --replica https://icp0.io --pem ~/.config/dfx/identity/default/identity.pem sync $canister_id build
 
         env:
           DFX_IDENTITY_PREVIEW: ${{ secrets.DFX_IDENTITY_PREVIEW }}

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -40,17 +40,16 @@ jobs:
         id: cache-icx-asset-bin
         uses: actions/cache@v3
         with:
-          path: sdk/target/debug/dfx
-          key: icxassetbin-19e18d1560aafedb3ab9764932755fd649be920a
+          path: sdk/target/release/icx-asset
+          key: icxassetbin-cce6ae0a2aeaee015612d49ce93047342e9fb4ec
           restore-keys: |
             - icxassetbin-
 
       - name: Install icx-asset
         if: steps.cache-icx-asset-bin.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/dfinity/sdk.git --single-branch
+          git clone -b akos/asset-upload-strategies --single-branch https://github.com/dfinity/sdk.git
           cd sdk
-          git checkout cce6ae0a2aeaee015612d49ce93047342e9fb4ec
           cargo build -p icx-asset --release
 
       - name: Add icx-asset to path


### PR DESCRIPTION
This PR tries to improve the PR preview deployment times by utilizing [an improved version of icx-asset](https://github.com/dfinity/sdk/pull/3766) to upload the assets, which increases parallelization.

This PR also tries to fix the issue of not releasing the preview canister properly if a PR is closed/merged while deployment is in progress,