### PR TITLE
chore: fix cache of icx-asset binary

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -43,7 +43,7 @@ jobs:
           path: sdk/target/release/icx-asset
           key: icxassetbin-cce6ae0a2aeaee015612d49ce93047342e9fb4ec
           restore-keys: |
-            - icxassetbin-
+            icxassetbin-
 
       - name: Install icx-asset
         if: steps.cache-icx-asset-bin.outputs.cache-hit != 'true'


### PR DESCRIPTION
The binary is currently rebuilt in each PR, resulting in an extra 3m run time.