### PR TITLE
Fix documentation for custom domains

### DIFF
--- a/docs/developer-docs/web-apps/custom-domains/dns-setup.mdx
+++ b/docs/developer-docs/web-apps/custom-domains/dns-setup.mdx
@@ -19,7 +19,7 @@ a subdomain on Namecheap to be used as a custom domain are listed. To illustrate
 configuration, the domain `ic-domain.live` and the subdomain `example.ic-domain.live` are used
 by configuring it to point to the canister with the ID `y5jqt-wqaaa-aaaam-abcoq-cai`.
 
-- #### Step 1: After purchasing your domain on Namecheap, open the management pane of your domain in the Namecheap dashboard.
+- #### Step 1: After purchasing your domain on Namecheap, open the management panel of your domain in the Namecheap dashboard.
 
 - #### Step 2: Open the **Advanced DNS** tab.
 
@@ -60,7 +60,7 @@ to point to the canister with the ID `y5jqt-wqaaa-aaaam-abcoq-cai`.
 
 ### Apex
 
-Unfortunately, GoDaddy does not support to configure a `CNAME` record (or one of its alternatives, `ALIAS` or `ANAME`) for the apex of the domain, you need to make use of a workaround.
+Unfortunately, GoDaddy does not support configuring a `CNAME` record (or one of its alternatives, `ALIAS` or `ANAME`) for the apex of the domain, you need to make use of a workaround.
 
   There are mainly two approaches:
 
@@ -77,7 +77,7 @@ It is explained in this approach using Cloudflare as DNS provider. It works simi
 with any other DNS provider that supports `CNAME`, `ALIAS`, or `ANAME` records
 for the apex of a domain.
 
-  - #### Step 1: Create a free account with Cloudflare, click on **Add site** in the top bar of dashboard.
+  - #### Step 1: Create a free account with Cloudflare, click on **Add site** in the top bar of the dashboard.
 
   - #### Step 2: Enter your domain (e.g., `ic-domain.online`) and click **Add site**.
 
@@ -86,7 +86,7 @@ for the apex of a domain.
   - #### Step 4: In the next step, Cloudflare lists two nameservers that you should configure GoDaddy to use.
   Take note of the two nameservers (e.g., `brianna.ns.cloudflare.com` and `kaiser.ns.cloudflare.com`) provided by Cloudflare.
 
-  - #### Step 5: In the **DNS Management** pane of GoDaddy, remove all DNS entries on GoDaddy.
+  - #### Step 5: In the **DNS Management** panel of GoDaddy, remove all DNS entries on GoDaddy.
   Go back to your DNS settings on Godaddy and make sure to remove all the DNS entries that GoDaddy created.
 
   - #### Step 6: Click on the **Change** button in the **Nameservers** section.

--- a/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
+++ b/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
@@ -53,7 +53,7 @@ a [concrete example to illustrate these steps](#concrete-example), followed by s
 instructions on [troubleshooting](#troubleshooting).
 
 - #### Step 1: Configure the DNS record of your domain, which is denoted with `CUSTOM_DOMAIN`.
-Add a `CNAME` entry for your domain pointing to `CUSTOM_DOMAIN.icp1.io` such that all the traffic destined to your domain is redirected to the boundary nodes;
+Add an `ALIAS` entry for your domain pointing to `CUSTOM_DOMAIN.icp1.io` such that all the traffic destined to your domain is redirected to the boundary nodes;
 Add a `TXT` entry containing the canister ID to the `_canister-id`-subdomain of your domain (e.g., `_canister-id.CUSTOM_DOMAIN`);
 Add a `CNAME` entry for the `_acme-challenge`-subdomain (e.g., `_acme-challenge.CUSTOM_DOMAIN`) pointing to `_acme-challenge.CUSTOM_DOMAIN.icp2.io` in order for the boundary nodes to acquire the certificate.
 
@@ -157,7 +157,7 @@ Imagine you wanted to register your domain `foo.bar.com` for your canister with 
 
 | Record Type   | Host                | Value                               |
 |---------------|---------------------|-------------------------------------|
-| `CNAME`       | @                   | foo.bar.com.icp1.io                 |
+| `ALIAS`       | @                   | foo.bar.com.icp1.io                 |
 | `TXT`         | _canister-id        | hwvjt-wqaaa-aaaam-qadra-cai         |
 | `CNAME`       | _acme-challenge     | _acme-challenge.foo.bar.com.icp2.io |
 

--- a/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
+++ b/docs/developer-docs/web-apps/custom-domains/using-custom-domains.mdx
@@ -165,6 +165,11 @@ Imagine you wanted to register your domain `foo.bar.com` for your canister with 
 Some DNS providers do not require you to specify the main domain. For example, you would just have to specify `foo` instead of `foo.bar.com`, `_canister-id.foo` instead of `_canister-id.foo.bar.com`, and `_acme-challenge.foo` instead of `_acme-challenge.foo.bar.com`.
 :::
 
+### Example on popular registrars
+
+In the [following document](dns-setup.mdx), this guide provides detailed instructions to configure DNS
+records on the example of two popular domain registrars.
+
 ### `.well-known/ic-domains`
 - #### Step 1: Create the `ic-domains` file with the following content in the `.well-known` directory:
     ```
@@ -195,11 +200,6 @@ curl -sLv -X POST \
 }
 EOF
 ```
-
-:::info
-In the [following document](dns-setup.mdx), this guide provides detailed instructions to configure DNS
-records on the example of two popular domain registrars.
-:::
 
 ### Troubleshooting
 


### PR DESCRIPTION
Fixes conflicting information on how to set up custom domains.

The following 2 pages currently don't agree:
- https://internetcomputer.org/docs/current/developer-docs/web-apps/custom-domains/using-custom-domains#dns-configuration
- https://internetcomputer.org/docs/current/developer-docs/web-apps/custom-domains/dns-setup#apex (see image in this section)

In my opinion, the following callout should also be introduced in the sidebar on the right.

> In the [following document](https://internetcomputer.org/docs/current/developer-docs/web-apps/custom-domains/dns-setup), this guide provides detailed instructions to configure DNS records on the example of two popular domain registrars.