### PR TITLE
Include security warning for 3rd party agents

### DIFF
--- a/docs/developer-docs/developer-tools/off-chain/agents/overview.mdx
+++ b/docs/developer-docs/developer-tools/off-chain/agents/overview.mdx
@@ -28,7 +28,7 @@ This section of the docs covers the following agents, ordered by languages:
 - Rust
   - [Rust agent by DFINITY](/docs/current/developer-docs/developer-tools/off-chain/agents/rust-agent)
 
-In addition to those, there are several other community-supported agents:
+In addition to those, there are several other community-supported agents. Note that these agents may be unmaintained or may not have undergone a security review, be sure to check their current status before using them:
 
 - .NET
   - [`ICP.NET` by Gekctek](https://github.com/Gekctek/ICP.NET)


### PR DESCRIPTION
Include security warning for 3rd party agents in the agent's overview page.