### PR TITLE
chore: correct `vote` method reference in `1.3-first-dapp.mdx`

### DIFF
--- a/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
+++ b/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
@@ -271,9 +271,9 @@ Then, the `Iter.toArray()` is a standard function that converts `Iter<(Text,Nat)
 :::
 
 
-### Declaring the `votes` method
+### Declaring the `vote` method
 
-Our next step is to create a new method called `votes` that uses an update call to update the canister's state.
+Our next step is to create a new method called `vote` that uses an update call to update the canister's state.
 
 Insert the following code into your `main.mo` file; there are inline comments that help explain the code's logic:
 


### PR DESCRIPTION
This pull request corrects the documentation reference for the `vote` method.