### PR TITLE
Update the launch steps' information about dapp canisters ownership

### DIFF
--- a/docs/developer-docs/daos/sns/launching/launch-steps-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-steps-1proposal.mdx
@@ -91,7 +91,7 @@ Nothing technical for dapp developers to do. Community votes.
 Nothing technical for dapp developers to do. This is triggered automatically as a result
 of an adopted proposal in Stage 4.
 
-### 6. (Automated) SNS-W sets SNS root as sole controller of dapp.
+### 6. (Automated) SNS-W sets SNS root and NNS root as sole controllers of dapp.
 
 Nothing technical for dapp developers to do. This is triggered automatically as a result
 of an adopted proposal in Stage 4.
@@ -116,4 +116,4 @@ of an adopted proposal in Stage 4.
 ### 10. (Automated) SNS swap finalizes.
 
 Nothing technical for dapp developers to do. This is triggered automatically as a result
-of an adopted proposal in Stage 4.
+of an adopted proposal in Stage 4. At this point, the SNS is fully launched and the dapp canisters are fully decentralized. The SNS root canister is also given full control of the dapp canisters.

--- a/docs/developer-docs/daos/sns/launching/launch-steps-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-steps-1proposal.mdx
@@ -65,6 +65,19 @@ One example of a special permission might be the ability to change the frontend 
 dfx canister call $CANISTER_ID revoke_permission '(record {of_principal = principal "<developer principal"; permission = variant { Commit;};})'
 ```
 
+:::warning
+Soon, if all goes well you will not personally have control over these canisters anymore. Instead, they will be controlled by the SNS, only updatable through SNS proposals. Furthermore, during the swap, the SNS will be in a restricted mode where some SNS proposal types cannot be submitted:
+
+1. `ManageNervousSystemParameters`
+2. `TransferSnsTreasuryFunds`
+3. `MintSnsTokens`
+4. `UpgradeSnsControlledCanister`
+5. `RegisterDappCanisters`
+6. `DeregisterDappCanisters`
+
+This means that it is not easy to upgrade an SNS-controlled dapp canister during the swap. However, since the SNS-controlled dapp canisters are co-owned by NNS root during a swap, it is still possible via an NNS proposal. This is intended to be used on an emergency basis and should be avoided if possible.
+:::
+
 ### 3. Submit NNS proposal to create SNS.
 
 Anyone who owns an eligible NNS neuron with enough stake can submit an NNS proposal to create an SNS for a given dapp.
@@ -81,6 +94,7 @@ To create such a proposal, a common path is to use `sns-cli` and run the followi
 ```bash
 dfx sns propose --network ic --neuron $NEURON_ID sns_init.yaml
 ```
+
 
 ### 4. The NNS proposal is decided.
 
@@ -116,4 +130,4 @@ of an adopted proposal in Stage 4.
 ### 10. (Automated) SNS swap finalizes.
 
 Nothing technical for dapp developers to do. This is triggered automatically as a result
-of an adopted proposal in Stage 4. At this point, the SNS is fully launched and the dapp canisters are fully decentralized. The SNS root canister is also given full control of the dapp canisters.
+of an adopted proposal in Stage 4. At this point, the SNS is fully launched and the dapp canisters are fully decentralized. The SNS root canister is also given full control of the dapp canisters. The SNS is no longer restricted and any proposal type can be submitted and executed.

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -90,6 +90,12 @@ If successful, at the end of stage, the following has changed:
   </tr>
 </table>
 
+:::warning
+Adding NNS root as co-controller is necessary because it needs to be able to make sure that no one else has the ability to change the canisters during the swap to ensure that the swap participants get what they expect. This is automatically done in a later step which sets NNS root and SNS root as the only controllers of the dapp canisters.
+
+This means that it is not easy to upgrade an SNS-controlled dapp canister during the swap. However, since the SNS-controlled dapp canisters are co-owned by NNS root during a swap, it is still possible via an NNS proposal in emergency situations. This is intended to be used on an emergency basis and should be avoided if possible. Once the swap is over, SNS root takes sole control of the dapp canisters and further upgrades are performed through SNS proposals.
+:::
+
 ### 3. Submit NNS proposal to create SNS.
 
 This proposal presents all the initial parameters for the SNS as defined in the first Stage to the NNS community.

--- a/docs/developer-docs/daos/sns/managing/making-proposals.mdx
+++ b/docs/developer-docs/daos/sns/managing/making-proposals.mdx
@@ -21,6 +21,20 @@ When the proposal is adopted, this method is called and executed fully on chain.
 
 In some cases, this method is on the SNS governance itself and in other cases, the method that is called can be defined in another canister.
 
+:::warning
+Most proposals can be submitted at any time. However, some proposals are not allowed during the SNS launch, until the swap has finished:
+
+1. `ManageNervousSystemParameters`
+2. `TransferSnsTreasuryFunds`
+3. `MintSnsTokens`
+4. `UpgradeSnsControlledCanister`
+5. `RegisterDappCanisters`
+6. `DeregisterDappCanisters`
+
+This means that it is not easy to upgrade an SNS-controlled dapp canister during the swap. However, since the SNS-controlled dapp canisters are co-owned by NNS root during a swap, it is still possible via an NNS proposal. This is intended to be used on an emergency basis and should be avoided if possible.
+:::
+
+
 ## Using quill to submit proposals
 
 ### Prerequisites


### PR DESCRIPTION
There will be a proposal to change the SNS launch process slightly to increase security:

1. NNS root now co-owns dapp canisters during the swap
2. Some proposal types are no longer allowed during the swap

This PR updates the docs in accordance with that proposal, but should not be merged until the proposal is approved