### PR TITLE
chore: correct `say` method reference in `2.2-advanced-canister-calls.mdx`

### DIFF
--- a/docs/tutorials/developer-journey/level-2/2.2-advanced-canister-calls.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.2-advanced-canister-calls.mdx
@@ -49,7 +49,7 @@ The amount of security your dapp needs depends on your dapp's use case and funct
 
 ### Example `query` call
 
-Queries are defined by the function modifier `query` in Motoko code. Below is a simple query call used with an `echo` function. It queries the function's result and does not make any changes to the canister's state or data.
+Queries are defined by the function modifier `query` in Motoko code. Below is a simple query call used with a `say` function. It queries the function's result and does not make any changes to the canister's state or data.
 
 
 ```motoko


### PR DESCRIPTION
This commit corrects the documentation reference for the `say` method.