### PR TITLE
correct docs sns_init.yaml link

### DIFF
--- a/docs/developer-docs/daos/sns/tokenomics/preparation.mdx
+++ b/docs/developer-docs/daos/sns/tokenomics/preparation.mdx
@@ -26,7 +26,7 @@ allows you to set these parameters and includes detailed descriptions of all par
 All SNS parameters are set in a **.yaml** file that can then be passed as an argument to the NNS proposal that triggers the SNS launch, both for testing and in production.
 To make sure that all parameters make sense and are also consistent with each other, it is recommended to test the proposal locally.
 
-**To create the SNS parameter yaml file, copy the template file found [here](https://github.com/dfinity/sns-testing/blob/main/example_sns_init.yaml) and fill in the fields with the desired values.** Note that this file is just an example and all of the values were chosen somewhat arbitrarily, so they should be adjusted to the specific desires of the SNS and not taken as official recommendations.
+**To create the SNS parameter yaml file, copy the [template file](https://github.com/dfinity/sns-testing/blob/main/example_sns_init.yaml) and fill in the fields with the desired values.** Note that this file is just an example, and all of the values were chosen somewhat arbitrarily, so they should be adjusted to the specific desires of the SNS and not taken as official recommendations.
 
 These are the categories of parameters that can be set:
 - **Parameters of the SNS governance canister**: these are parameters of the governance

--- a/docs/developer-docs/daos/sns/tokenomics/preparation.mdx
+++ b/docs/developer-docs/daos/sns/tokenomics/preparation.mdx
@@ -26,7 +26,7 @@ allows you to set these parameters and includes detailed descriptions of all par
 All SNS parameters are set in a **.yaml** file that can then be passed as an argument to the NNS proposal that triggers the SNS launch, both for testing and in production.
 To make sure that all parameters make sense and are also consistent with each other, it is recommended to test the proposal locally.
 
-**To create the SNS parameter yaml file, copy the template file found [here](https://github.com/dfinity/ic/blob/master/rs/sns/cli/sns_init_template.yaml) and fill in the fields with the desired values. An example configuration file with filled out fields can be found in [sns-testing](https://github.com/dfinity/sns-testing/blob/main/example_sns_init.yaml).**
+**To create the SNS parameter yaml file, copy the template file found [here](https://github.com/dfinity/sns-testing/blob/main/example_sns_init.yaml) and fill in the fields with the desired values.** Note that this file is just an example and all of the values were chosen somewhat arbitrarily, so they should be adjusted to the specific desires of the SNS and not taken as official recommendations.
 
 These are the categories of parameters that can be set:
 - **Parameters of the SNS governance canister**: these are parameters of the governance


### PR DESCRIPTION
The docs previously pointed to an obsolete sns_init.yaml. Thank you to [peterparker](https://forum.dfinity.org/t/sns-yaml-invalid-minimim-and-maximum-icp-fields-naming/32796/3) on the forum for pointing this out