### PR TITLE
chore: Update message to request in resource limits

### DIFF
--- a/docs/developer-docs/smart-contracts/maintain/resource-limits.mdx
+++ b/docs/developer-docs/smart-contracts/maintain/resource-limits.mdx
@@ -23,7 +23,7 @@ The limits depend on the message type as shown in the following table.
 | Message queue limit, messages per <GlossaryTooltip>canister</GlossaryTooltip>                                           | 500         |
 | Maximum ingress message payload                                                      | 2MB         |
 | Maximum cross-net inter-canister message payload                                     | 2MB         |
-| Maximum same-<GlossaryTooltip>subnet</GlossaryTooltip> inter-canister message payload (may be deprecated at some point) | 10MB        |
+| Maximum same-<GlossaryTooltip>subnet</GlossaryTooltip> inter-canister request payload (may be deprecated at some point) | 10MB        |
 | Maximum response size (replicated execution)                                         | 2MB         |
 | Maximum response size (non-replicated execution, i.e. in query calls)                | 3MB         |
 


### PR DESCRIPTION
Use "request" instead of "message" for the same-subnet request limit to make it more clear that this only applies to requests and the limit is different for responses (covered later in the table).