### PR TITLE
fix: Fixing the order of cycles top-up parameters in the documentation

### DIFF
--- a/docs/developer-docs/defi/cycles/cycles-ledger.mdx
+++ b/docs/developer-docs/defi/cycles/cycles-ledger.mdx
@@ -132,10 +132,10 @@ Using suffixes such as `500k` or `5TC` is supported. [View the full list of suff
 To transfer cycles into a canister to top it up, use the command:
 
 ```
-dfx cycles top-up `AMOUNT` `CANISTER_ID` --network ic
+dfx cycles top-up `CANISTER_ID` `AMOUNT` --network ic
 ```
 
-Replace `AMOUNT` with the number of cycles, such as `34000000`, and `CANISTER_ID` with the canister ID you'd like to transfer the cycles to, such as `gastn-uqaaa-aaaae-aaafq-cai`.
+Replace `CANISTER_ID` with the canister ID you'd like to transfer the cycles to, such as `gastn-uqaaa-aaaae-aaafq-cai`, and `AMOUNT` with the number of cycles, such as `100000000`.
 
 ### Creating a canister using cycles
 


### PR DESCRIPTION
The PR fixes the issue reported on the [forum](https://forum.dfinity.org/t/topping-up-a-canister/33876).