### PR TITLE
Remove: old dfx 0.16.0 examples

### DIFF
--- a/docs/developer-docs/ai/machine-learning-sample.mdx
+++ b/docs/developer-docs/ai/machine-learning-sample.mdx
@@ -3,6 +3,7 @@ keywords: [intermediate, tutorial, machine learning, ml, mnist, rust]
 ---
 
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import '/src/components/CenterImages/center.scss';
 
 # Machine learning sample

--- a/docs/developer-docs/ai/machine-learning-sample.mdx
+++ b/docs/developer-docs/ai/machine-learning-sample.mdx
@@ -52,6 +52,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'Vanilla JS':
 
 ```

--- a/docs/developer-docs/ai/machine-learning-sample.mdx
+++ b/docs/developer-docs/ai/machine-learning-sample.mdx
@@ -2,11 +2,6 @@
 keywords: [intermediate, tutorial, machine learning, ml, mnist, rust]
 ---
 
-import TabItem from "@theme/TabItem";
-import useBaseUrl from "@docusaurus/useBaseUrl";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import '/src/components/CenterImages/center.scss';
 
@@ -39,9 +34,6 @@ This project is based off of one [found within the Rust Burn examples](https://g
 ## Creating a new project
 
 To get started, create a new project in your working directory. Open a terminal window, then use the commands:
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -86,19 +78,6 @@ Then, navigate into the new project directory:
 ```
 cd machine_learning_sample
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new machine_learning_sample --type=rust
-cd machine_learning_sample
-```
-
-</TabItem>
-</AdornedTabs>
 
 You can also [clone the GitHub repo for this project](https://github.com/smallstepman/ic-mnist.git) if you want to get started quickly.
 

--- a/docs/developer-docs/backend/rust/10-timers.mdx
+++ b/docs/developer-docs/backend/rust/10-timers.mdx
@@ -2,10 +2,6 @@
 keywords: [beginner, rust, tutorial, periodic tasks, timers]
 ---
 
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
@@ -23,9 +19,6 @@ Before getting started, assure you have set up your developer environment accord
 ## Create the timer dapp project
 
 Open a terminal window on your local computer, if you don’t already have one open.
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -63,17 +56,6 @@ Lastly, you can include extra features to be added to your project:
 ⬚ Bitcoin (Regtest)
 ⬚ Frontend tests
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new my_timers --type=rust --no-frontend
-```
-
-</TabItem>
-</AdornedTabs>
 
 Then, navigate into your project directory by running the command:
 

--- a/docs/developer-docs/backend/rust/10-timers.mdx
+++ b/docs/developer-docs/backend/rust/10-timers.mdx
@@ -36,6 +36,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/developer-docs/backend/rust/12-searching-records.mdx
+++ b/docs/developer-docs/backend/rust/12-searching-records.mdx
@@ -37,10 +37,6 @@ Before getting started, assure you have set up your developer environment accord
 
 Open a terminal window on your local computer, if you don’t already have one open. Then, create a new project by running the following command:
 
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
 Use `dfx new <project_name>` to create a new project:
 
 ```
@@ -77,17 +73,6 @@ Lastly, you can include extra features to be added to your project:
 ⬚ Bitcoin (Regtest)
 ⬚ Frontend tests
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new rust_profile --type=rust --no-frontend
-```
-
-</TabItem>
-</AdornedTabs>
 
 Then, navigate into your project directory by running the command:
 

--- a/docs/developer-docs/backend/rust/12-searching-records.mdx
+++ b/docs/developer-docs/backend/rust/12-searching-records.mdx
@@ -53,6 +53,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/developer-docs/backend/rust/2-project-organization.mdx
+++ b/docs/developer-docs/backend/rust/2-project-organization.mdx
@@ -2,10 +2,6 @@
 keywords: [beginner, rust, tutorial, project organization]
 ---
 
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # 2: Project organization
@@ -16,9 +12,6 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 When a new Rust project is created with the command:
 
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
 ```
 dfx new example
 
@@ -28,17 +21,6 @@ dfx new example
   TypeScript (Azle)
   Python (Kybra)
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new --type rust example
-```
-
-</TabItem>
-</AdornedTabs>
 
 the following project structure is generated:
 

--- a/docs/developer-docs/backend/rust/2-project-organization.mdx
+++ b/docs/developer-docs/backend/rust/2-project-organization.mdx
@@ -47,6 +47,10 @@ src
 webpack.config.js
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 In this structure, you can see the backend canister, in this case `example_backend` contains the following components:
 
 src/example_backend:

--- a/docs/developer-docs/backend/rust/4-quickstart.mdx
+++ b/docs/developer-docs/backend/rust/4-quickstart.mdx
@@ -37,6 +37,11 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
+
 Then, select a frontend framework for your frontend canister, or select 'No frontend canister':
 
 ```

--- a/docs/developer-docs/backend/rust/4-quickstart.mdx
+++ b/docs/developer-docs/backend/rust/4-quickstart.mdx
@@ -2,11 +2,6 @@
 keywords: [beginner, rust, tutorial, quickstart]
 ---
 
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
@@ -25,9 +20,6 @@ Before getting started, assure you have set up your developer environment accord
 ## Creating a new Rust project
 
 To create a new Rust project using the IC SDK, open a terminal window and run the following command:
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -65,17 +57,6 @@ Lastly, you can include extra features to be added to your project:
 ⬚ Bitcoin (Regtest)
 ⬚ Frontend tests
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new --type=rust rust_hello
-```
-
-</TabItem>
-</AdornedTabs>
 
 
 Next, navigate into your project directory by running the following command:

--- a/docs/developer-docs/backend/rust/5-deploying.mdx
+++ b/docs/developer-docs/backend/rust/5-deploying.mdx
@@ -2,7 +2,6 @@
 keywords: [beginner, rust, tutorial, deploying canisters, deploying]
 ---
 
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
@@ -24,9 +23,43 @@ Before getting started, assure you have set up your developer environment accord
 
 Open a terminal window on your local computer, if you don’t already have one open.
 
-First, create a new dfx project with the command:
+Use `dfx new [project_name]` to create a new project:
 
-<DfxNewSnippet />
+```
+dfx new hello_world
+```
+
+You will be prompted to select the language that your backend canister will use:
+
+```
+? Select a backend language: ›
+❯ Motoko
+Rust
+TypeScript (Azle)
+Python (Kybra)
+```
+
+Then, select a frontend framework for your frontend canister. In this example, select:
+
+```
+? Select a frontend framework: ›
+SvelteKit
+React
+Vue
+❯ Vanilla JS
+No JS template
+No frontend canister
+```
+
+Lastly, you can include extra features to be added to your project:
+
+```
+? Add extra features (space to select, enter to confirm) ›
+⬚ Internet Identity
+⬚ Bitcoin (Regtest)
+⬚ Frontend tests
+```
+
 
 By default, the project structure will resemble the following:
 

--- a/docs/developer-docs/backend/rust/5-deploying.mdx
+++ b/docs/developer-docs/backend/rust/5-deploying.mdx
@@ -39,6 +39,11 @@ TypeScript (Azle)
 Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
+
 Then, select a frontend framework for your frontend canister. In this example, select:
 
 ```

--- a/docs/developer-docs/backend/rust/9-counter.mdx
+++ b/docs/developer-docs/backend/rust/9-counter.mdx
@@ -2,10 +2,6 @@
 keywords: [beginner, rust, tutorial, counter]
 ---
 
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # 9: Incrementing a counter
@@ -35,9 +31,6 @@ Before getting started, assure you have set up your developer environment accord
 Open a terminal window on your local computer, if you don’t already have one open.
 
 Start by creating a new project by running the following command:
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -75,17 +68,6 @@ Lastly, you can include extra features to be added to your project:
 ⬚ Bitcoin (Regtest)
 ⬚ Frontend tests
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new rust_counter --type=rust --no-frontend
-```
-
-</TabItem>
-</AdornedTabs>
 
 Then, navigate into your project directory by running the command:
 

--- a/docs/developer-docs/backend/rust/9-counter.mdx
+++ b/docs/developer-docs/backend/rust/9-counter.mdx
@@ -48,6 +48,11 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/developer-docs/backend/rust/index.mdx
+++ b/docs/developer-docs/backend/rust/index.mdx
@@ -2,10 +2,6 @@
 keywords: [beginner, rust, introduction]
 ---
 
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # Introduction to developing canisters in Rust
@@ -16,9 +12,6 @@ Rust is a powerful and type-sound modern programming language with an active dev
 
 ## Overview
 To help pave the way for writing dapps in Rust that can be deployed on the Internet Computer blockchain, you can use the [IC SDK](/docs/current/developer-docs/getting-started/install/). The IC SDK supports the Rust as well as the Motoko programming language. To create a Rust project using the IC SDK, all one needs to do is add the `--type=rust` flag while creating a new project. For example, here you create a Rust project named `hello_world`:
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -35,17 +28,6 @@ You will be prompted to select the language that your backend canister will use.
   TypeScript (Azle)
   Python (Kybra)
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx new --type=rust hello_world
-```
-
-</TabItem>
-</AdornedTabs>
 
 To start a new project see [Rust quick start](4-quickstart.mdx).
 

--- a/docs/developer-docs/backend/rust/index.mdx
+++ b/docs/developer-docs/backend/rust/index.mdx
@@ -13,8 +13,6 @@ Rust is a powerful and type-sound modern programming language with an active dev
 ## Overview
 To help pave the way for writing dapps in Rust that can be deployed on the Internet Computer blockchain, you can use the [IC SDK](/docs/current/developer-docs/getting-started/install/). The IC SDK supports the Rust as well as the Motoko programming language. To create a Rust project using the IC SDK, all one needs to do is add the `--type=rust` flag while creating a new project. For example, here you create a Rust project named `hello_world`:
 
-Use `dfx new <project_name>` to create a new project:
-
 ```
 dfx new hello_world
 ```
@@ -29,7 +27,11 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
-To start a new project see [Rust quick start](4-quickstart.mdx).
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
+For more information on starting a new project see [Rust quick start](4-quickstart.mdx).
 
 ## Architecture
 

--- a/docs/developer-docs/developer-tools/off-chain/agents/javascript-agent.mdx
+++ b/docs/developer-docs/developer-tools/off-chain/agents/javascript-agent.mdx
@@ -2,7 +2,6 @@
 keywords: [intermediate, agents, tutorial, javascript]
 ---
 
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # JavaScript agent

--- a/docs/developer-docs/getting-started/hello-world.mdx
+++ b/docs/developer-docs/getting-started/hello-world.mdx
@@ -115,6 +115,10 @@ You will be prompted to select the language that your backend <GlossaryTooltip>c
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend <GlossaryTooltip>canister</GlossaryTooltip>, or select 'No frontend canister':
 
 ```

--- a/docs/developer-docs/getting-started/quickstart/juno-quickstart.mdx
+++ b/docs/developer-docs/getting-started/quickstart/juno-quickstart.mdx
@@ -2,7 +2,6 @@
 keywords: [beginner, getting started, quickstart, juno]
 ---
 
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/developer-docs/getting-started/quickstart/react-quickstart.mdx
+++ b/docs/developer-docs/getting-started/quickstart/react-quickstart.mdx
@@ -38,6 +38,10 @@ TypeScript (Azle)
 Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. In this example, select:
 
 ```

--- a/docs/developer-docs/getting-started/quickstart/react-quickstart.mdx
+++ b/docs/developer-docs/getting-started/quickstart/react-quickstart.mdx
@@ -2,8 +2,6 @@
 keywords: [beginner, getting started, quickstart, react]
 ---
 
-
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
@@ -24,9 +22,42 @@ When developing on ICP, the primary tool used by developers is the [IC SDK](/doc
 
 To create your own dapp, you can either edit the default template created by `dfx` which provides a framework for a backend canister and frontend canister, use an example or boilerplate project repository, or create a project from scratch.
 
-To create a new project with `dfx`, first assure you have downloaded and installed the [IC SDK](/docs/current/developer-docs/getting-started/install/). Then, you can run the command:
+To create a new project with `dfx`, first assure you have downloaded and installed the [IC SDK](/docs/current/developer-docs/getting-started/install/). Then, you can run the command `dfx new [project_name]` to create a new project:
 
-<DfxNewSnippet />
+```
+dfx new hello_world
+```
+
+You will be prompted to select the language that your backend canister will use:
+
+```
+? Select a backend language: ›
+❯ Motoko
+Rust
+TypeScript (Azle)
+Python (Kybra)
+```
+
+Then, select a frontend framework for your frontend canister. In this example, select:
+
+```
+? Select a frontend framework: ›
+SvelteKit
+React
+Vue
+❯ Vanilla JS
+No JS template
+No frontend canister
+```
+
+Lastly, you can include extra features to be added to your project:
+
+```
+? Add extra features (space to select, enter to confirm) ›
+⬚ Internet Identity
+⬚ Bitcoin (Regtest)
+⬚ Frontend tests
+```
 
 By default, the dapp's frontend assets are stored in the `src/my_project_frontend` subdirectory, which contains an `assets` directory used to store frontend assets and a `src` directory used to store the frontend code. To customize your dapp's frontend, you can make changes to the files in the `src/my_project_frontend/assets` and `src/my_project_frontend/src` subdirectories.
 

--- a/docs/developer-docs/identity/internet-identity/integrate-internet-identity.mdx
+++ b/docs/developer-docs/identity/internet-identity/integrate-internet-identity.mdx
@@ -48,6 +48,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'Vanilla JS':
 
 ```

--- a/docs/developer-docs/identity/internet-identity/integrate-internet-identity.mdx
+++ b/docs/developer-docs/identity/internet-identity/integrate-internet-identity.mdx
@@ -3,6 +3,10 @@ keywords: [intermediate, tutorial, user sign in, user login, internet identity]
 ---
 
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
+import TabItem from "@theme/TabItem";
+import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
+import { AdornedTab } from "/src/components/Tabs/AdornedTab";
+import { BetaChip } from "/src/components/Chip/BetaChip";
 
 # Integrating with II
 
@@ -20,15 +24,7 @@ Before you start, verify that you have:
 - Downloaded and installed [`dfx`](https://github.com/dfinity/sdk/releases/latest) version 0.14.1 or later.
 - [Node.js v16+](https://nodejs.org/en).
 
-### Step 1: To get started, open a terminal window and create a new project:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
+### Step 1: To get started, open a terminal window and create a new project.
 
 Start `dfx`:
 
@@ -72,82 +68,6 @@ x Internet Identity
 ⬚ Bitcoin (Regtest)
 ⬚ Frontend tests
 ```
-
-
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-Start `dfx`:
-
-```
-dfx start --clean --background
-```
-
-Use `dfx new <project_name>` to create a new project:
-
-```bash
-dfx new ii_integration
-```
-
-As mentioned in the introduction, you'll be using the **pullable** version of the Internet Identity canister, which uses the `dfx deps` workflow. The project's `dfx.json` file defines the Internet Identity canister as `"type": "pull"`.
-
-Open the `dfx.json` file and replace the existing content with the following:
-
-
-```json
-{
-  "canisters": {
-    "ii_integration_backend": {
-      "main": "src/ii_integration_backend/main.mo",
-      "type": "motoko"
-    },
-    "internet_identity" : {
-      "type": "pull",
-      "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"
-    },
-    "ii_integration_frontend": {
-      "dependencies": [
-        "ii_integration_backend"
-      ],
-      "frontend": {
-        "entrypoint": "src/ii_integration_frontend/src/index.html"
-      },
-      "source": [
-        "src/ii_integration_frontend/assets",
-        "dist/ii_integration_frontend/"
-      ],
-      "type": "assets"
-    }
-  },
-  "defaults": {
-    "build": {
-      "args": "",
-      "packtool": ""
-    }
-  },
-  "output_env_file": ".env",
-  "version": 1
-}
-```
-
-Pull the II canister using `dfx deps`:
-
-```
-dfx deps pull
-```
-
-Initialize the canister. You can use the `'(null)'` value passed to the init command to use the default values. To do so, run the command:
-
-```
-dfx deps init internet_identity --argument '(null)'
-```
-
-
-</TabItem>
-</AdornedTabs>
-
 
 ### Step 2: For this project, you'll use a simple 'Who am I?' function for the backend canister. Open the `src/ii_integration_backend/main.mo` file and replace the existing content with the following:
 

--- a/docs/developer-docs/web-apps/application-frontends/default-frontend.mdx
+++ b/docs/developer-docs/web-apps/application-frontends/default-frontend.mdx
@@ -97,6 +97,10 @@ You will be prompted to select the language that your backend canister will use:
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'React':
 
 ```

--- a/docs/tutorials/developer-journey/level-0/06-intro-dfx.mdx
+++ b/docs/tutorials/developer-journey/level-0/06-intro-dfx.mdx
@@ -2,7 +2,6 @@
 keywords: [beginner, tutorial, developer journey, introduction, dfx]
 ---
 
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
@@ -87,7 +86,40 @@ Assure that you are in your working directory, `developer_journey`.
 
 ### Step 2: Create a new project with the name 'hello_world' with the command:
 
-<DfxNewSnippet />
+```
+dfx new hello_world
+```
+
+You will be prompted to select the language that your backend canister will use:
+
+```
+? Select a backend language: ›
+❯ Motoko
+Rust
+TypeScript (Azle)
+Python (Kybra)
+```
+
+Then, select a frontend framework for your frontend canister. In this example, select:
+
+```
+? Select a frontend framework: ›
+SvelteKit
+React
+Vue
+❯ Vanilla JS
+No JS template
+No frontend canister
+```
+
+Lastly, you can include extra features to be added to your project:
+
+```
+? Add extra features (space to select, enter to confirm) ›
+⬚ Internet Identity
+⬚ Bitcoin (Regtest)
+⬚ Frontend tests
+```
 
 When no flags are used, the `dfx new` command will create a new project using the default Motoko template. To create a project using the Rust project template, the flag `--type=rust` should be included in the command. 
 

--- a/docs/tutorials/developer-journey/level-0/06-intro-dfx.mdx
+++ b/docs/tutorials/developer-journey/level-0/06-intro-dfx.mdx
@@ -100,6 +100,10 @@ TypeScript (Azle)
 Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. In this example, select:
 
 ```

--- a/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
+++ b/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
@@ -44,6 +44,10 @@ TypeScript (Azle)
 Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. In this example, select:
 
 ```

--- a/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
+++ b/docs/tutorials/developer-journey/level-1/1.3-first-dapp.mdx
@@ -2,7 +2,6 @@
 keywords: [beginner, tutorial, developer journey, first dapp]
 ---
 
-import DfxNewSnippet from "/src/components/Snippets/DfxNewSnippet.mdx";
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import '/src/components/CenterImages/center.scss';
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
@@ -28,13 +27,43 @@ Before you start, verify that you have set up your developer environment accordi
 
 ## Creating a new project
 
-First, you need to create a new `dfx` project. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
+First, you need to create a new `dfx` project. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```bash
 dfx start --clean --background
+dfx new hello_world
 ```
 
-<DfxNewSnippet />
+You will be prompted to select the language that your backend canister will use:
+
+```
+? Select a backend language: ›
+❯ Motoko
+Rust
+TypeScript (Azle)
+Python (Kybra)
+```
+
+Then, select a frontend framework for your frontend canister. In this example, select:
+
+```
+? Select a frontend framework: ›
+SvelteKit
+React
+Vue
+❯ Vanilla JS
+No JS template
+No frontend canister
+```
+
+Lastly, you can include extra features to be added to your project:
+
+```
+? Add extra features (space to select, enter to confirm) ›
+⬚ Internet Identity
+⬚ Bitcoin (Regtest)
+⬚ Frontend tests
+```
 
 ## Reviewing the project's file structure
 

--- a/docs/tutorials/developer-journey/level-2/2.1-storage-persistence.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.1-storage-persistence.mdx
@@ -100,6 +100,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-2/2.1-storage-persistence.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.1-storage-persistence.mdx
@@ -81,15 +81,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -134,23 +126,6 @@ Then, navigate into the new project directory:
 ```
 cd counter
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new counter --no-frontend
-cd counter
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
-
 
 Then, open the file `src/counter_backend/main.mo`. Delete all of the content within this file.
 

--- a/docs/tutorials/developer-journey/level-2/2.3-third-party-canisters.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.3-third-party-canisters.mdx
@@ -48,6 +48,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-2/2.3-third-party-canisters.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.3-third-party-canisters.mdx
@@ -29,16 +29,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 Use `dfx new <project_name>` to create a new project:
 
@@ -83,23 +74,6 @@ Then, navigate into the new project directory:
 ```
 cd dependencies
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new dependencies --no-frontend
-cd dependencies
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
-
 
 You'll use the default 'Hello world' project in this example, then you'll pull the Internet Identity canister as a dependency of our `dependencies_backend` canister.
 

--- a/docs/tutorials/developer-journey/level-2/2.4-intro-candid.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.4-intro-candid.mdx
@@ -6,7 +6,6 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import '/src/components/CenterImages/center.scss';
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 
-
 # 2.4 Introduction to Candid
 
 <MarkdownChipRow labels={["Intermediate", "Tutorial"]} />
@@ -210,17 +209,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -263,21 +252,6 @@ Then, navigate into the new project directory:
 ```
 cd candid_example
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new candid_example
-cd candid_example
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-</TabItem>
-</AdornedTabs>
 
 You'll be using the sample Motoko canister that you looked at in the [generating service descriptions](#generating-service-descriptions) section earlier. Open the `src/candid_example_backend/main.mo` file in your code editor and replace the existing code with the following:
 

--- a/docs/tutorials/developer-journey/level-2/2.4-intro-candid.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.4-intro-candid.mdx
@@ -226,6 +226,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-2/2.5-unit-testing.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.5-unit-testing.mdx
@@ -170,6 +170,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-2/2.5-unit-testing.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.5-unit-testing.mdx
@@ -153,17 +153,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -206,21 +196,6 @@ Then, navigate into the new project directory:
 ```
 cd e2e_tests
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new e2e_tests --no-frontend
-cd e2e_tests
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-</TabItem>
-</AdornedTabs>
 
 ### Setting up the project
 

--- a/docs/tutorials/developer-journey/level-2/2.6-motoko-lvl2.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.6-motoko-lvl2.mdx
@@ -252,6 +252,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-2/2.6-motoko-lvl2.mdx
+++ b/docs/tutorials/developer-journey/level-2/2.6-motoko-lvl2.mdx
@@ -235,17 +235,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -288,22 +278,6 @@ Then, navigate into the new project directory:
 ```
 cd multiple_actors
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new multiple_actors
-cd multiple_actors
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
 
 ### Configuring canisters in `dfx.json`
 

--- a/docs/tutorials/developer-journey/level-3/3.1-package-managers.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.1-package-managers.mdx
@@ -73,6 +73,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-3/3.1-package-managers.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.1-package-managers.mdx
@@ -56,17 +56,7 @@ Finally, to initialize Vessel, run `vessel init` in your project's root folder.
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -109,21 +99,6 @@ Then, navigate into the new project directory:
 ```
 cd mops_example
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new mops_example
-cd mops_example
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-</TabItem>
-</AdornedTabs>
 
 ### Configuring your project to use Mops
 

--- a/docs/tutorials/developer-journey/level-3/3.2-https-outcalls.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.2-https-outcalls.mdx
@@ -73,17 +73,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -126,22 +116,6 @@ Then, navigate into the new project directory:
 ```
 cd https_get
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new https_get --no-frontend
-cd https_get
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
 
 ### Creating an HTTP `GET` request
 

--- a/docs/tutorials/developer-journey/level-3/3.2-https-outcalls.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.2-https-outcalls.mdx
@@ -90,6 +90,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-3/3.6-motoko-lvl3.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.6-motoko-lvl3.mdx
@@ -86,17 +86,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -139,22 +129,6 @@ Then, navigate into the new project directory:
 ```
 cd access_hello
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new access_hello
-cd access_hello
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
 
 
 ### Creating an `owner` identity

--- a/docs/tutorials/developer-journey/level-3/3.6-motoko-lvl3.mdx
+++ b/docs/tutorials/developer-journey/level-3/3.6-motoko-lvl3.mdx
@@ -103,6 +103,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-4/4.1-icp-ledger.mdx
+++ b/docs/tutorials/developer-journey/level-4/4.1-icp-ledger.mdx
@@ -80,6 +80,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-4/4.1-icp-ledger.mdx
+++ b/docs/tutorials/developer-journey/level-4/4.1-icp-ledger.mdx
@@ -63,17 +63,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -116,22 +106,6 @@ Then, navigate into the new project directory:
 ```
 cd icp_ledger_canister
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new icp_ledger_canister
-cd icp_ledger_canister
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
 
 ### Locating the Wasm and Candid files
 

--- a/docs/tutorials/developer-journey/level-4/4.2-icrc-tokens.mdx
+++ b/docs/tutorials/developer-journey/level-4/4.2-icrc-tokens.mdx
@@ -109,6 +109,10 @@ You will be prompted to select the language that your backend canister will use.
   Python (Kybra)
 ```
 
+:::info
+`dfx` versions `v0.17.0` and newer support this `dfx new` interactive prompt. [Learn more about `dfx v0.17.0`](/blog/2024/02/14/news-and-updates/update#dfx-v0170).
+:::
+
 Then, select a frontend framework for your frontend canister. Select 'No frontend canister':
 
 ```

--- a/docs/tutorials/developer-journey/level-4/4.2-icrc-tokens.mdx
+++ b/docs/tutorials/developer-journey/level-4/4.2-icrc-tokens.mdx
@@ -92,17 +92,7 @@ Before you start, verify that you have set up your developer environment accordi
 
 ### Creating a new project
 
-To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the commands:
-
-import TabItem from "@theme/TabItem";
-import { AdornedTabs } from "/src/components/Tabs/AdornedTabs";
-import { AdornedTab } from "/src/components/Tabs/AdornedTab";
-import { BetaChip } from "/src/components/Chip/BetaChip";
-
-<AdornedTabs groupId="version">
-<TabItem value="0-17-0" label="dfx v0.17.0 or newer" default>
-
-Use `dfx new <project_name>` to create a new project:
+To get started, create a new project in your working directory. Open a terminal window, navigate into your working directory (`developer_journey`), then use the following commands to start `dfx` and create a new project:
 
 ```
 dfx start --clean --background
@@ -145,23 +135,6 @@ Then, navigate into the new project directory:
 ```
 cd icrc1_ledger_canister
 ```
-
-</TabItem>
-
-<TabItem value="0-16-1" label="dfx v0.16.1 or older" default>
-
-```bash
-dfx start --clean --background
-dfx new icrc1_ledger_canister
-cd icrc1_ledger_canister
-```
-
-Remember, by default `dfx new` creates a new project in the Motoko language. If you'd like to create a Rust project, use the flag `--type=rust`.
-
-
-</TabItem>
-</AdornedTabs>
-
 
 ### Locating the Wasm and Candid files
 


### PR DESCRIPTION
Removing tabs that indicates different instructions for dfx 0.16.0 and dfx 0.17.0 since it has been 6 months since dfx 0.17.0's release, and there have been several new releases since then (latest version 0.22.0). 

Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [ ] Follows the [developer docs style guide](style-guide.md).
- [ ] Follows the [best practices and guidelines](README.md#best-practices).
- [ ] New documentation pages include [document tags](README.md#document-tags).
- [ ] New documentation pages include [SEO keywords](README#seo-keywords).
- [ ] New documents are in the `.mdx` file format to support the previous two components. 
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [ ] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
