### PR TITLE
fix: use new domain for synthetic testnet

### DIFF
--- a/docs/developer-docs/smart-contracts/deploy/custom-testnets.mdx
+++ b/docs/developer-docs/smart-contracts/deploy/custom-testnets.mdx
@@ -159,7 +159,7 @@ To define a project-specific network, add a "networks" section to your `dfx.json
 "networks": {
     "myNetwork": {
       "providers": [
-        "https://ic0.app"
+        "https://icp0.io"
       ],
       "type": "persistent"
     }


### PR DESCRIPTION
ic0.app is outdated and should no longer be used