### PR TITLE
docs(evm-rpc): add explanation of `NonceTooLow` transaction status

### DIFF
--- a/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
+++ b/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
@@ -798,6 +798,10 @@ dfx canister call evm_rpc eth_sendRawTransaction "(variant {$RPC_SOURCE}, $RPC_C
 </TabItem>
 </AdornedTabs>
 
+Note that some JSON-RPC APIs may only return a `NonceTooLow` status when successfully submitting a transaction. This is because during HTTP outcall consensus, only the first request is successful while the others respond with a duplicate transaction. 
+
+If you encounter this issue, one possible workaround is to use a deduplicating proxy server such as the community built C-ATTS EVM RPC proxy ([source code](https://github.com/c-atts/catts-evm-rpc-proxy)). 
+
 ### Error "already known"
 
 Sending a transaction to the Ethereum network is a state changing operation. Since the EVM-RPC canister sends a transaction to some JSON-RPC providers via HTTPs outcalls, each contacted provider will receive the same transaction multiple times.

--- a/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
+++ b/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
@@ -798,9 +798,9 @@ dfx canister call evm_rpc eth_sendRawTransaction "(variant {$RPC_SOURCE}, $RPC_C
 </TabItem>
 </AdornedTabs>
 
-Note that some JSON-RPC APIs may only return a `NonceTooLow` status when successfully submitting a transaction. This is because during HTTP outcall consensus, only the first request is successful while the others respond with a duplicate transaction. 
+Note that some JSON-RPC APIs may only return a `NonceTooLow` status when successfully submitting a transaction. This is because during HTTP outcall consensus, only the first request is successful while the others reply with a duplicate transaction status. 
 
-If you encounter this issue, one possible workaround is to use a deduplicating proxy server such as the community built C-ATTS EVM RPC proxy ([source code](https://github.com/c-atts/catts-evm-rpc-proxy)). 
+If you encounter this issue, one possible workaround is to use a deduplicating proxy server such as the community-built C-ATTS EVM RPC proxy ([source code](https://github.com/c-atts/catts-evm-rpc-proxy)). 
 
 ### Error "already known"
 


### PR DESCRIPTION
This PR includes an explanation of the `NonceTooLow` status in the EVM RPC canister's `eth_sendRawTransaction` method, along with a suggested workaround which mentions the community-built [C-ATTS EVM RPC proxy server](https://github.com/c-atts/catts-evm-rpc-proxy).

CC @kristoferlund.