### PR TITLE
Fix broken link for Threshold signatures documentation

### DIFF
--- a/docs/developer-docs/multi-chain/overview.mdx
+++ b/docs/developer-docs/multi-chain/overview.mdx
@@ -426,7 +426,7 @@ There are several building blocks available to augment non-ICP smart contracts w
 
 - **[EVM RPC canister](/docs/current/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister)**: A canister smart contract providing an on-chain API for communicating with [Ethereum](https://ethereum.org/en/) or any other [EVM blockchain](https://chainlist.org/?testnets=true).
 
-- **[Threshold signatures](/docs/current/references/t-ecdsa-how-it-works//)**: An ICP service implementing the threshold ECDSA and threshold Schnorr protocols.
+- **[Threshold signatures](/docs/current/references/t-ecdsa-how-it-works)**: An ICP service implementing the threshold ECDSA and threshold Schnorr protocols.
 
 - **[HTTPS outcalls](/docs/current/developer-docs/security/security-best-practices/https-outcalls)**: Replicated calls into external web services.
 


### PR DESCRIPTION
Fix broken link for Threshold signatures documentation

This pull request corrects a broken link in the documentation for Threshold signatures by removing an double forward slash ("//") from the link URL.

Changes made:
- Removed double "/" from the Threshold signatures documentation link
- The corrected link now properly redirects to the intended documentation page

Before: /docs/current/references/t-ecdsa-how-it-works//
After:  /docs/current/references/t-ecdsa-how-it-works

This fix ensures that users can access the correct Threshold signatures documentation without encountering a redirect error.

Contribution Checklist:
- [x] Follows the [developer docs style guide](style-guide.md).
- [x] Follows the [best practices and guidelines](README.md#best-practices).
- [ ] New documentation pages include [document tags](README.md#document-tags). (N/A - no new pages added)
- [ ] New documentation pages include [SEO keywords](README#seo-keywords). (N/A - no new pages added)
- [ ] New documents are in the `.mdx` file format to support the previous two components. (N/A - no new documents added)
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js). (N/A - no new documents added)
- [ ] [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is updated with new documents. (N/A - no new documents added)
