### PR TITLE
Remove references to `RpcService::Chain()` variant

### DIFF
--- a/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
+++ b/docs/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister.mdx
@@ -215,7 +215,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_getLogs "(variant {$RPC_SOURCE}, $RPC_CONFIG, record {addresses = vec {\"ADDRESS\"}})" --with-cycles=$CYCLES --wallet=$WALLET
@@ -305,7 +304,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_getBlockByNumber "(variant {$RPC_SOURCE}, $RPC_CONFIG, variant {Latest})" --with-cycles=$CYCLES --wallet=$WALLET
@@ -395,7 +393,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_getTransactionReceipt "(variant {$RPC_SOURCE}, $RPC_CONFIG, \"TRANSACTION_ID\")" --with-cycles=$CYCLES --wallet=$WALLET
@@ -572,7 +569,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_getTransactionCount "(variant {$RPC_SOURCE}, $RPC_CONFIG, record {address = \"CONTRACT_ADDRESS\"; block = variant {Latest}})" --with-cycles=$CYCLES --wallet=$WALLET
@@ -686,7 +682,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_feeHistory "(variant {$RPC_SOURCE}, $RPC_CONFIG, record {blockCount = 3; newestBlock = variant {Latest}})" --with-cycles=$CYCLES --wallet=$WALLET
@@ -788,7 +783,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_sendRawTransaction "(variant {$RPC_SOURCE}, $RPC_CONFIG, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" --with-cycles=$CYCLES --wallet=$WALLET
@@ -894,7 +888,6 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc request "(variant {$JSON_RPC_SOURCE}, "'"{ \"jsonrpc\": \"2.0\", \"method\": \"eth_gasPrice\", \"params\": [], \"id\": 1 }"'", 1000)" --with-cycles=$CYCLES --wallet=$WALLET // Local deployment
@@ -979,7 +972,6 @@ type RpcService = variant {
   BaseMainnet : L2MainnetService;
   OptimismMainnet : L2MainnetService;
   ...
-  Chain : nat64;
   Provider : nat64;
   Custom : record { url : text; headers : opt vec (text, text) };
 };

--- a/docs/developer-docs/multi-chain/ethereum/evm-rpc/how-it-works.mdx
+++ b/docs/developer-docs/multi-chain/ethereum/evm-rpc/how-it-works.mdx
@@ -131,7 +131,6 @@ type RpcService = variant {
   ArbitrumOne : L2MainnetService;
   BaseMainnet : L2MainnetService;
   OptimismMainnet : L2MainnetService;
-  Chain : nat64;
   Provider : nat64;
   Custom : record { url : text; headers : opt vec HttpHeader };
 };

--- a/docs/developer-docs/multi-chain/ethereum/using-eth/submit-transactions.mdx
+++ b/docs/developer-docs/multi-chain/ethereum/using-eth/submit-transactions.mdx
@@ -25,11 +25,10 @@ IDENTITY=default
 CYCLES=1000000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 # Send a raw transaction
-dfx canister call evm_rpc eth_sendRawTransaction "(variant {$SOURCE}, $RPC_CONFIG, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" --with-cycles=$CYCLES --wallet=$WALLET
+dfx canister call evm_rpc eth_sendRawTransaction "(variant {$RPC_SOURCE}, $RPC_CONFIG, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" --with-cycles=$CYCLES --wallet=$WALLET
 ```
 
 [Learn more about the EVM RPC canister](/docs/current/developer-docs/multi-chain/ethereum/evm-rpc/evm-rpc-canister).

--- a/docs/tutorials/developer-journey/level-5/5.2-ICP-ETH-tutorial.mdx
+++ b/docs/tutorials/developer-journey/level-5/5.2-ICP-ETH-tutorial.mdx
@@ -214,7 +214,6 @@ IDENTITY=default
 CYCLES=1500000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_feeHistory "(variant {$RPC_SOURCE}, $RPC_CONFIG, record {blockCount = 3; newestBlock = variant {Latest}})" --with-cycles=$CYCLES --wallet=$WALLET
@@ -318,7 +317,6 @@ IDENTITY=default
 CYCLES=1500000000
 WALLET=$(dfx identity get-wallet)
 RPC_SOURCE=EthMainnet
-JSON_RPC_SOURCE=Chain=1
 RPC_CONFIG=null
 
 dfx canister call evm_rpc eth_sendRawTransaction "(variant {$RPC_SOURCE}, $RPC_CONFIG, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" --with-cycles=$CYCLES --wallet=$WALLET


### PR DESCRIPTION
Updates the EVM RPC documentation to remove references to the deprecated `RpcService::Chain()` variant, which will be removed in the next version of the canister.

Context: https://github.com/internet-computer-protocol/evm-rpc-canister/pull/273.