### PR TITLE
Reintroduce `no-repl` config for Motoko code snippets

### DIFF
--- a/src/theme/CodeBlock/Content/String.js
+++ b/src/theme/CodeBlock/Content/String.js
@@ -46,9 +46,8 @@ export default function StringWrapper(props) {
   const [output, setOutput] = useState("");
   const [error, setError] = useState("");
 
-  const showRunButton = useMemo(() => {
-    return props.className === "language-motoko";
-  }, [props.className]);
+  const showRunButton =
+    props.className === "language-motoko" && !props.hasOwnProperty("no-repl");
 
   return (
     <div style={{ position: "relative" }}>


### PR DESCRIPTION
This PR reintroduces the `no-repl` configuration to deactivate the "Run" button for a Motoko code snippet.

Example:

````motoko
```motoko no-repl
actor {
    ...
}
```
````