### PR TITLE
fix: topping-up-canister Option 2 command

### DIFF
--- a/docs/developer-docs/smart-contracts/topping-up/topping-up-canister.mdx
+++ b/docs/developer-docs/smart-contracts/topping-up/topping-up-canister.mdx
@@ -80,7 +80,7 @@ If you have a cycles balance associated with your developer identity, you can to
 
 ```bash
 dfx cycles balance --network ic
-dfx cycles top-up `AMOUNT` `CANISTER_ID` --network ic
+dfx cycles top-up `CANISTER_ID` `AMOUNT` --network ic
 ```
 
 This workflow uses the cycles ledger, a feature that requires `dfx` version `0.19.0`. To enable this feature, you will need to set the following environmental variable:


### PR DESCRIPTION
Existing: dfx cycles top-up `AMOUNT` `CANISTER_ID` --network ic
New: dfx cycles top-up `CANISTER_ID` `AMOUNT`  --network ic

Cycles topup command takes Canister id first then amount. Without this pattern it returns this error.

error: invalid value 'jqylk-byaaa-aaaal-qbymq-cai' for '<AMOUNT>': Unknown amount specifier: 'i'
