### PR TITLE
Update icrc1_ledger_setup.mdx to avoid error messages when the user tries to follow the instructions

### DIFF
--- a/docs/developer-docs/defi/tokens/ledger/setup/icrc1_ledger_setup.mdx
+++ b/docs/developer-docs/defi/tokens/ledger/setup/icrc1_ledger_setup.mdx
@@ -77,8 +77,8 @@ If you chose to download the ICRC-1 ledger files with the script, you need to re
 
 ``` json
 ...
-"candid": icrc1_ledger.did,
-"wasm" : icrc1_ledger.wasm.gz,
+"candid": "icrc1_ledger.did",
+"wasm" : "icrc1_ledger.wasm.gz"
   ...
 ```
 


### PR DESCRIPTION
Without this change, the user will see the following error:

```
% dfx identity use default
error: failed to parse /.../icrc1_ledger_canister/dfx.json as json
error:     caused by: expected value at line 5 column 17
```