### PR TITLE
Add docs for swap start time

### DIFF
--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -346,7 +346,7 @@ At this point, the SNS canisters exist and the dapp canisters are under SNS DAO 
 
 An algorithm is applied to allow at least 24 hours between the time the CreateServiceNervousSystem proposal is executed and the swap start. For example, if the start time specified in the proposal is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 minutes from the proposal execution time).
 
-**WARNING**: The timing protocol for swap start works differently on mainnet and in testing.
+**WARNING**: The timing protocol for the swap start works differently on the mainnet and in testing.
 
 On mainnet:
 - Setting the start time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -342,7 +342,7 @@ If successful, at the end of stage, the following has changed:
 
 At this point, the SNS canisters exist and the dapp canisters are under SNS DAO control. The initial SNS neurons can use SNS proposals to take the last steps to decentralize the dapp canisters, for example by giving certain permissions to the SNS governance canister stating that these functions can only be triggered by SNS DAO proposal. One example of this is the asset canister (see details [here](../managing/sns-asset-canister.mdx)).
 
-### 8. Timing Protocol for Swap Start
+### 8. Timing protocol for swap start
 
 An algorithm is applied to allow at least 24 hours between the time of execution of the CreateServiceNervousSystem proposal and swap start. For example, if the start time specified in the proposal is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 min from the proposal execution time).
 
@@ -350,11 +350,11 @@ An algorithm is applied to allow at least 24 hours between the time of execution
 
 On mainnet:
 - Setting the start time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.
-- If start time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
+- If a start time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
 
 In testing:
 - Setting the start time to some value works the same as explained above.
-- If start time is not specified, the swap will begin immediately after the CreateServiceNervousSystem proposal is executed. This facilitates testing in an accelerated manner.
+- If a start time is not specified, the swap will begin immediately after the CreateServiceNervousSystem proposal is executed. This facilitates testing in an accelerated manner.
 
 ### 9. (Automatically) SNS swap starts.
 The swap was initialized with a defined start time.

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -348,8 +348,8 @@ An algorithm is applied to allow at least 24 hours between the time the CreateSe
 
 **WARNING**: The timing protocol for the swap start works differently on the mainnet and in testing.
 
-On mainnet:
-- Setting the start time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.
+On the mainnet:
+- Setting the start time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICP tokens that they could participate with.
 - If a start time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
 
 In testing:

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -342,21 +342,19 @@ If successful, at the end of stage, the following has changed:
 
 At this point, the SNS canisters exist and the dapp canisters are under SNS DAO control. The initial SNS neurons can use SNS proposals to take the last steps to decentralize the dapp canisters, for example by giving certain permissions to the SNS governance canister stating that these functions can only be triggered by SNS DAO proposal. One example of this is the asset canister (see details [here](../managing/sns-asset-canister.mdx)).
 
-### 8. Swap is adopted but not yet started.
+### 8. Timing Protocol for Swap Start
 
-An algorithm is applied to allow at least 24 hours between the time of execution of the CreateServiceNervousSystem proposal and swap start. For example, if start_time is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 min from the proposal execution time).
+An algorithm is applied to allow at least 24 hours between the time of execution of the CreateServiceNervousSystem proposal and swap start. For example, if the start time specified in the proposal is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 min from the proposal execution time).
 
-**WARNING**: Swap start_time works differently on mainnet and in testing.
+**WARNING**: The timing protocol for swap start works differently on mainnet and in testing.
 
 On mainnet:
-- Setting start_time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.
-- If start_time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
+- Setting the start time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.
+- If start time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
 
 In testing:
-- Setting start_time to some value works the same as explained above.
-- If start_time is not specified, the swap will begin immediately after
-  the CreateServiceNervousSystem proposal is executed. This facilitates
-  testing in an accelerated manner.
+- Setting the start time to some value works the same as explained above.
+- If start time is not specified, the swap will begin immediately after the CreateServiceNervousSystem proposal is executed. This facilitates testing in an accelerated manner.
 
 ### 9. (Automatically) SNS swap starts.
 The swap was initialized with a defined start time.

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -344,7 +344,7 @@ At this point, the SNS canisters exist and the dapp canisters are under SNS DAO 
 
 ### 8. Timing protocol for swap start
 
-An algorithm is applied to allow at least 24 hours between the time of execution of the CreateServiceNervousSystem proposal and swap start. For example, if the start time specified in the proposal is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 min from the proposal execution time).
+An algorithm is applied to allow at least 24 hours between the time the CreateServiceNervousSystem proposal is executed and the swap start. For example, if the start time specified in the proposal is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 minutes from the proposal execution time).
 
 **WARNING**: The timing protocol for swap start works differently on mainnet and in testing.
 

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -342,7 +342,23 @@ If successful, at the end of stage, the following has changed:
 
 At this point, the SNS canisters exist and the dapp canisters are under SNS DAO control. The initial SNS neurons can use SNS proposals to take the last steps to decentralize the dapp canisters, for example by giving certain permissions to the SNS governance canister stating that these functions can only be triggered by SNS DAO proposal. One example of this is the asset canister (see details [here](../managing/sns-asset-canister.mdx)).
 
-### 8. (Automatically) SNS swap starts.
+### 8. Swap is adopted but not yet started.
+
+An algorithm is applied to allow at least 24 hours between the time of execution of the CreateServiceNervousSystem proposal and swap start. For example, if start_time is 23:30 UTC and the proposal is adopted and executed at 23:20 UTC, then the swap start will be at 23:30 UTC the next day (i.e., in 24 hours and 10 min from the proposal execution time).
+
+**WARNING**: Swap start_time works differently on mainnet and in testing.
+
+On mainnet:
+- Setting start_time to some value (e.g., 23:30 UTC) will allow the swap participants to be prepared for the swap in advance, e.g., by obtaining ICPs that they would like to participate with.
+- If start_time is not specified, the actual start time of the swap will be chosen at random (allowing at least 24 hours and less than 48 hours, as described above).
+
+In testing:
+- Setting start_time to some value works the same as explained above.
+- If start_time is not specified, the swap will begin immediately after
+  the CreateServiceNervousSystem proposal is executed. This facilitates
+  testing in an accelerated manner.
+
+### 9. (Automatically) SNS swap starts.
 The swap was initialized with a defined start time.
 Once this start time is reached,
 the swap will automatically be started and is open for participation.
@@ -392,7 +408,7 @@ This means, you will have the following situation:
   </tr>
 </table>
 
-### 9. (Automatically) SNS swap ends.
+### 10. (Automatically) SNS swap ends.
 The swap was also initialized with a defined end time.
 When this time is reached, the swap automatically ends.
 The swap can also end earlier if the maximum ICP participation is reached before the end
@@ -441,7 +457,7 @@ This means, you will have the following situation:
 </table>
 
 
-### 10. (Automatically) SNS swap finalizes.
+### 11. (Automatically) SNS swap finalizes.
 When the decentralization swap ends, it is first established whether
 it was successful, e.g., enough ICP have been collected.
 If the swap was successful,

--- a/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
+++ b/docs/developer-docs/daos/sns/launching/launch-summary-1proposal.mdx
@@ -25,7 +25,7 @@ The NNS community's approval is relevant in Stage 3.
   * The token name, token symbol, ledger transaction fee.
   * The tokenomics and how governance will work.
   * The initial token distribution.
-  * The conditions for the decentralization swap, including the swap's start date and
+  * The conditions for the decentralization swap, including the swap's start time (see Step 8) and
     how many ICP tokens should at least and at most be collected.
 
   Therefore defining these parameters usually requires a lot of preparation and


### PR DESCRIPTION
We should include the precise logic on the start_time of a swap. This description is mostly copied from the example sns_init.yaml in sns-testing