### PR TITLE
Updated spelling for Oisy -> OISY

### DIFF
--- a/showcase.json
+++ b/showcase.json
@@ -460,7 +460,7 @@
   },
   {
     "id": "oisy",
-    "name": "Oisy Wallet",
+    "name": "OISY Wallet",
     "oneLiner": "Browser-based multi-chain wallet",
     "website": "https://oisy.com",
     "github": "https://github.com/dfinity/oisy-wallet",


### PR DESCRIPTION
We're updating the title to use the updated one in the Internet Identity: 
![image](https://github.com/user-attachments/assets/2b627044-1321-4713-a9a3-b0cbcc39a798)
