### PR TITLE
Update indexes.mdx

### DIFF
--- a/docs/developer-docs/defi/tokens/indexes.mdx
+++ b/docs/developer-docs/defi/tokens/indexes.mdx
@@ -202,7 +202,7 @@ The ICP index canister will start synching right away and will automatically try
 Here it is assumed that the canister ID of your local ICRC-1 ledger is `mxzaz-hqaaa-aaaar-qaada-cai`, otherwise replace it with your ICRC-1 ledger canister ID.
 
 ```
-dfx deploy icrc1_index_canister --argument '(opt variant{Init = record {ledger_id = principal "mxzaz-hqaaa-aaaar-qaada-cai" retrieve_blocks_from_ledger_interval_seconds: Some(10)}})'
+dfx deploy icrc1_index_canister --argument '(opt variant { Init = record { ledger_id = principal "mxzaz-hqaaa-aaaar-qaada-cai"; retrieve_blocks_from_ledger_interval_seconds = opt 10; } })'
 ```
 
 :::caution


### PR DESCRIPTION
The command listed on the page:
dfx deploy icrc1_index_canister --argument '(opt variant{Init = record {ledger_id = principal "mxzaz-hqaaa-aaaar-qaada-cai" retrieve_blocks_from_ledger_interval_seconds: Some(10)}})'

returns an error:
error: parser error
  ┌─ Candid argument:1:81
  │
1 │ (opt variant{Init = record {ledger_id = principal "mxzaz-hqaaa-aaaar-qaada-cai" retrieve_blocks_from_ledger_interval_seconds: Some(10)}})
  │                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected token
  │
  = Expects one of ":", ";", "}"

Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to install all canisters. Caused by: Failed to install wasm module to canister 'index_canister'. Caused by: Failed to create argument blob.
Caused by: Invalid data: Unable to serialize Candid values: Invalid argument: Invalid Candid values: Candid parser error: Unrecognized token `Id("retrieve_blocks_from_ledger_interval_seconds")` found at 80:124 Expected one of ":", ";" or "}"


The error here is due to the syntax used in the argument format. In Candid, each field in a record must be separated by a semicolon (;) rather than just whitespace. Here’s how to adjust the syntax to address the error:

dfx deploy icrc1_index_canister --argument '(opt variant { Init = record { ledger_id = principal "mxzaz-hqaaa-aaaar-qaada-cai"; retrieve_blocks_from_ledger_interval_seconds = opt 10; } })'

Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [x] Follows the [developer docs style guide](style-guide.md).
- [x] Follows the [best practices and guidelines](README.md#best-practices).
- [x] New documentation pages include [document tags](README.md#document-tags).
- [x] New documentation pages include [SEO keywords](README#seo-keywords).
- [x] New documents are in the `.mdx` file format to support the previous two components. 
- [x] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [x] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
