### PR TITLE
Update stellarator milestone

### DIFF
--- a/roadmap/entries/data-icp_as_compute_platform.json
+++ b/roadmap/entries/data-icp_as_compute_platform.json
@@ -54,7 +54,7 @@
       "proposal": "",
       "docs": "",
       "eta": "Q2 2024",
-      "status": "in_progress",
+      "status": "deployed",
       "is_community": false,
       "in_beta": false,
       "milestone_id": "Stellarator"
@@ -78,10 +78,9 @@
       "proposal": "",
       "docs": "",
       "eta": "",
-      "status": "in_progress",
+      "status": "deployed",
       "is_community": false,
       "in_beta": false,
-      "milestone_id": "Stellarator",
       "imported": true
     },
     {

--- a/roadmap/entries/data-icp_as_compute_platform.json
+++ b/roadmap/entries/data-icp_as_compute_platform.json
@@ -81,7 +81,8 @@
       "status": "deployed",
       "is_community": false,
       "in_beta": false,
-      "imported": true
+      "imported": true,
+      "milestone_id": "Stellarator"
     },
     {
       "title": "Improved consensus throughput and latency",
@@ -116,8 +117,7 @@
       "eta": "",
       "status": "in_progress",
       "is_community": false,
-      "in_beta": false,
-      "milestone_id": "Stellarator"
+      "in_beta": false
     },
     {
       "title": "Increased Storage Capacity and Throughput",


### PR DESCRIPTION
The previous PR #3709 changed the wrong file so the update was not reflected on the website. This PR is to fix this.