### PR TITLE
chore: release Interface Spec v0.29.0

### DIFF
--- a/docs/references/_attachments/ic.did
+++ b/docs/references/_attachments/ic.did
@@ -5,6 +5,7 @@ type snapshot_id = blob;
 type log_visibility = variant {
     controllers;
     public;
+    allowed_viewers : vec principal;
 };
 
 type canister_settings = record {

--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,10 @@
 ## Changelog {#changelog}
 
+### 0.29.0 (2024-11-14) {#0_29_0}
+* Allow anonymous query and read state requests with invalid `ingress_expiry`.
+* Add allowed viewers variant to canister log visibility.
+* Deprecate the Bitcoin API of the management canister.
+
 ### 0.28.0 (2024-10-11) {#0_28_0}
 * Add new management canister methods for canister snapshot support.
 


### PR DESCRIPTION
This PR releases the latest commit `b7cbca243f527b6819a0b0f644f87366a47d3eb4` of the master branch in the dfinity/interface-spec repository.