### PR TITLE
[FINAL] feat: Add sections for new subnet_info endpoint

### DIFF
--- a/docs/references/_attachments/ic.did
+++ b/docs/references/_attachments/ic.did
@@ -343,6 +343,14 @@ type node_metrics_history_result = vec record {
     node_metrics : vec node_metrics;
 };
 
+type subnet_info_args = record {
+    subnet_id : principal;
+};
+
+type subnet_info_result = record {
+    replica_version : text;
+};
+
 type provisional_create_canister_with_cycles_args = record {
     amount : opt nat;
     settings : opt canister_settings;
@@ -444,6 +452,9 @@ service ic : {
 
     // metrics interface
     node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
+
+    // subnet info
+    subnet_info : (subnet_info_args) -> (subnet_info_result);
 
     // provisional interfaces for the pre-ledger world
     provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);

--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,8 @@
 ## Changelog {#changelog}
 
+### 0.30.0 (2024-11-19) {#0_30_0}
+* Add management canister endpoint `subnet_info`.
+
 ### 0.29.0 (2024-11-14) {#0_29_0}
 * Allow anonymous query and read state requests with invalid `ingress_expiry`.
 * Add allowed viewers variant to canister log visibility.

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -2550,6 +2550,14 @@ A single metric entry is a record with the following fields:
 
 - `num_block_failures_total` (`nat64`): the number of failed block proposals by this node.
 
+### IC method `subnet_info` {#ic-subnet-info}
+
+This method can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
+
+Given a subnet ID as input, this method returns a record `subnet_info` containing metadata about that subnet.
+
+Currently, the only field returned is the `replica_version` (`text`) of the targeted subnet.
+
 ### IC method `take_canister_snapshot` {#ic-take_canister_snapshot}
 
 This method can be called by canisters as well as by external users via ingress messages.
@@ -5473,6 +5481,33 @@ S with
       }
 
 ```
+
+#### IC Management Canister: Subnet Metrics
+
+The management canister returns subnet metadata given a subnet ID.
+
+Conditions
+
+```html
+S.messages = Older_messages · CallMessage M · Younger_messages 
+(M.queue = Unordered) or (∀ CallMessage M' | FuncMessage M' ∈ Older_messages. M'.queue ≠ M.queue) 
+M.callee = ic_principal 
+M.method_name = 'subnet_info'
+R = <implementation-specific> 
+```
+
+State after
+
+```html
+S with 
+    messages = Older_messages · Younger_messages · 
+      ResponseMessage { 
+        origin = M.origin 
+        response = Reply (candid(R)) 
+        refunded_cycles = M.transferred_cycles 
+      }
+```
+
 
 #### IC Management Canister: Canister creation with cycles
 

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -5482,7 +5482,7 @@ S with
 
 ```
 
-#### IC Management Canister: Subnet Metrics
+#### IC Management Canister: Subnet information
 
 The management canister returns subnet metadata given a subnet ID.
 


### PR DESCRIPTION
In certain circumstances, canisters wish to learn about subnet-specific data or metadata. This endpoint enables these use cases, starting with exposing the replica version a subnet is currently running.