### PR TITLE
feat: allow canister http outcalls to specify transform of another canister

### DIFF
--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -2487,7 +2487,7 @@ The following parameters should be supplied for the call:
 
 -   `body` - optional, the content of the request's body
 
--   `transform` - an optional record that includes a function that transforms raw responses to sanitized responses, and a byte-encoded context that is provided to the function upon invocation, along with the response to be sanitized. If provided, the calling canister itself must export this function.
+-   `transform` - an optional record that includes a function that transforms raw responses to sanitized responses, and a byte-encoded context that is provided to the function upon invocation, along with the response to be sanitized. If provided, the transform function must be exposed by a canister on the same subnet as the calling canister.
 
 Cycles to pay for the call must be explicitly transferred with the call, i.e., they are not automatically deducted from the caller's balance implicitly (e.g., as for inter-canister calls).
 
@@ -2501,7 +2501,7 @@ The returned response (and the response provided to the `transform` function, if
 
 The `transform` function may, for example, transform the body in any way, add or remove headers, modify headers, etc. The maximal number of bytes representing the response produced by the `transform` function is `2MB` (`2,000,000B`). Note that the number of bytes representing the response produced by the `transform` function includes the serialization overhead of the encoding produced by the canister.
 
-When the transform function is invoked by the system due to a canister HTTP request, the caller's identity is the principal of the management canister. This information can be used by developers to implement access control mechanism for this function.
+When the transform function is invoked by the system due to a canister HTTP request, the caller's identity is the principal of the management canister if the canister making the canister HTTP request is the same as the canister exposing the transform function, otherwise the caller's identity is the principal of the canister making the canister HTTP request. This information can be used by developers to implement access control mechanism for this function.
 
 The following additional limits apply to HTTP requests and HTTP responses from the remote sever:
 


### PR DESCRIPTION
This PR allows canister http outcalls to specify the transform function exposed by another canister (on the same subnet).