### PR TITLE
Update to 1TiB total size and 500 GiB stable

### DIFF
--- a/docs/developer-docs/smart-contracts/maintain/resource-limits.mdx
+++ b/docs/developer-docs/smart-contracts/maintain/resource-limits.mdx
@@ -38,13 +38,13 @@ The limits depend on the message type as shown in the following table.
 
 | <Tooltip text="A collection of nodes that run their own instance of the ICP consensus algorithm.">Subnet</Tooltip> limits                                                                        | Constraint  |
 | ------------------------------------------------------------------------------------ | ----------- |
-| Subnet capacity (total memory available per subnet)                                  | 700GiB      |
+| Subnet capacity (total memory available per subnet)                                  | 1TiB        |
 | Maximum number of snapshot per canister                                              | 1           |
 
 | Memory resource limits                                                               | Constraint  |
 | ------------------------------------------------------------------------------------ | ----------- |
 | Wasm heap memory, per canister                                                       | 4GiB        |
-| Wasm stable memory, per canister                                                     | 400GiB      |
+| Wasm stable memory, per canister                                                     | 500GiB      |
 | Wasm stable memory, data access per replicated message                               | 2GiB        |
 | Wasm stable memory, data written per replicated message                              | 2GiB        |
 | Wasm stable memory, data access per upgrade message                                  | 8GiB        |


### PR DESCRIPTION
This updates the state size limit and the stable memory limit to the latest replica values.
