### PR TITLE
chore: tag PR with interface-spec

### DIFF
--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -1,16 +1,21 @@
-name: "check cddl and candid files"
+name: Interface Specification
 on:
   pull_request:
     paths:
+      - .github/workflows/interface-spec.yml
+      - docs/references/http-gateway-protocol-spec.md
+      - docs/references/ic-interface-spec.md
       - docs/references/_attachments/certificates.cddl
-      - docs/references/_attachments/requests.cddl
       - docs/references/_attachments/http-gateway.did
       - docs/references/_attachments/ic.did
+      - docs/references/_attachments/interface-spec-changelog.md
+      - docs/references/_attachments/requests.cddl
   push:
     branches:
       - main
 jobs:
-  cddl-candid:
+  cddl:
+    name: Check cddl files
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -19,9 +24,25 @@ jobs:
       run: |
         docker run --rm -v $PWD/docs/references/_attachments:/workdir ghcr.io/anweiss/cddl-cli:0.9.1 compile-cddl --cddl /workdir/certificates.cddl
         docker run --rm -v $PWD/docs/references/_attachments:/workdir ghcr.io/anweiss/cddl-cli:0.9.1 compile-cddl --cddl /workdir/requests.cddl
+  candid:
+    name: Check candid files
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
     - name: Check candid files
       run: |
         curl -L https://github.com/dfinity/candid/releases/download/2023-07-25/didc-linux64 -o didc
         chmod +x didc
         ./didc check docs/references/_attachments/http-gateway.did
         ./didc check docs/references/_attachments/ic.did
+  interface-spec-tag:
+    name: Tag PR with interface-spec
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag PR with interface-spec
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label interface-spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -41,8 +41,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Tag PR with interface-spec
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label interface-spec
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Tag PR with interface-spec
+      run: |
+        gh pr edit ${{ github.event.pull_request.number }} --add-label interface-spec
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR sets up a CI job to automatically tag PRs touching Interface Specification with the interface-spec tag.