### PR TITLE
Add a GH workflow to check for non-svg icons in the showcase.

### DIFF
--- a/.github/workflows/check-showcase-icons-svg.yml
+++ b/.github/workflows/check-showcase-icons-svg.yml
@@ -1,0 +1,31 @@
+name: Allow only SVG files in the showcase
+
+on:
+  push:
+    paths:
+      - statuc/img/showcase/**  # Monitor the directory where images are stored
+  pull_request:
+    paths:
+      - statuc/img/showcase/**  # Run on PRs that modify files in this directory
+
+jobs:
+  check-svgs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for non-SVG files
+        run: |
+          # Find new or modified files in the "images" directory
+          files=$(git diff --name-only ${{ github.event.before }} HEAD -- statuc/img/showcase/)
+          
+          # Loop through the files and check extensions
+          for file in $files; do
+            if [[ "$file" != *.svg ]]; then
+              echo "❌ Non-SVG file detected: $file"
+              exit 1
+            fi
+          done
+          echo "✅ All added/modified files are SVGs"


### PR DESCRIPTION
# Motivation

Keeping the icons for the showcase small.

# Changes

Add a github workflow that checks that the icons in the showcase directory are SVGs.

# Tests

I'll test this after it's deployed with a new PR adding an icon that is not SVG, they I'll change it to a PR.

If the workflow works as expected, I will add it as a necessary check before merging the PR.

# Contribution Info

Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [ ] Follows the [developer docs style guide](style-guide.md).
- [ ] Follows the [best practices and guidelines](README.md#best-practices).
- [ ] New documentation pages include [document tags](README.md#document-tags).
- [ ] New documentation pages include [SEO keywords](README#seo-keywords).
- [ ] New documents are in the `.mdx` file format to support the previous two components. 
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [ ] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
