### PR TITLE
docs: list major data of  list_canister_snapshots returns

### DIFF
--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -2635,6 +2635,8 @@ This method can be called by canisters as well as by external users via ingress 
 
 This method lists the snapshots of the canister identified by `canister_id`. Only controllers of the canister can list its snapshots. Currently, at most one snapshot per canister will be stored.
 
+The results notably include the snapshot's unique identifier and its size in bytes.
+
 ### IC method `delete_canister_snapshot` {#ic-delete_canister_snapshot}
 
 This method can be called by canisters as well as by external users via ingress messages.


### PR DESCRIPTION
# Motivation

When I added support for snapshots in Juno, I was confused about the `size` information returned by `list_canister_snapshots`. I wasn’t sure if it was measured in bytes or another unit, as the Candid file only specifies a byte array and there were no additional references in the documentation.

This is why I submit this PR to clarify that the size is measured in bytes and to mention that the result includes a unique ID.

Note that I explicitly omitted the timestamp because the sentence structure I provided here ensures maintainability—meaning we wouldn’t need to update the description every time new self-explanatory fields are added.