### PR TITLE
fix: Link HTTPS outcalls to the https outcalls overview page

### DIFF
--- a/docs/developer-docs/multi-chain/overview.mdx
+++ b/docs/developer-docs/multi-chain/overview.mdx
@@ -434,7 +434,7 @@ There are several building blocks available to augment non-ICP smart contracts w
 
 - **[Threshold signatures](/docs/current/references/t-ecdsa-how-it-works)**: An ICP service implementing the threshold ECDSA and threshold Schnorr protocols.
 
-- **[HTTPS outcalls](/docs/current/developer-docs/security/security-best-practices/https-outcalls)**: Replicated calls into external web services.
+- **[HTTPS outcalls](/docs/current/developer-docs/smart-contracts/advanced-features/https-outcalls/https-outcalls-overview)**: Replicated calls into external web services.
 
 - **[Bitcoin API](/docs/current/references/bitcoin-how-it-works)**: A protocol API that allows canisters to interact with the Bitcoin blockchain directly.
 


### PR DESCRIPTION
The link points to the security section, seems like it would make more sense to point to the https outcalls overview.

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [x] Follows the [developer docs style guide](style-guide.md).
- [x] Follows the [best practices and guidelines](README.md#best-practices).
- [x] New documentation pages include [document tags](README.md#document-tags).
- [x] New documentation pages include [SEO keywords](README#seo-keywords).
- [x] New documents are in the `.mdx` file format to support the previous two components. 
- [x] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [x] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
