### PR TITLE
Add link targets for page footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -745,6 +745,7 @@ const config = {
               {
                 label: "Node Providers",
                 href: "/node-providers",
+                target: '_self',
               },
               {
                 label: "Dashboard",


### PR DESCRIPTION
add target _self for linkes like "Node Providers" in page footer menu as they link to a pages on the same website