### PR TITLE
Updated link in the hero

### DIFF
--- a/src/components/LandingPage/Hero/Hero.tsx
+++ b/src/components/LandingPage/Hero/Hero.tsx
@@ -73,12 +73,13 @@ const Hero: React.FC<{
                 >
                   <LinkArrowRight /> <span>What is ICP</span>
                 </Link>
+
                 <Link
                   className="link-primary link-with-icon !text-white  hover:text-white hover:opacity-80 duration-200 ease-in-out"
-                  href="https://internetcomputer.docsend.com/view/dzkwezufykwpb7p8"
+                  href="/library"
                 >
-                  <span>Read the ICP Deck</span> <LinkArrowUpRight />
-                </Link>
+                  <LinkArrowRight /> <span>Guides, decks and papers</span>
+                </Link> 
               </div>
             </div>
             <aside


### PR DESCRIPTION
There is a request to update the link in the hero section that instead of the deck will point to the Library page

<img width="1681" alt="image" src="https://github.com/user-attachments/assets/7f6606aa-b743-4a2a-b3ba-9806de8145aa" />
<img width="485" alt="image" src="https://github.com/user-attachments/assets/96648990-ed86-4ffd-b97c-c270b7d11d79" />
