### PR TITLE
fix(ICRC_Ledger): FI-1654: Update link to script that downloads latest ICRC ledger

### DIFF
--- a/docs/developer-docs/defi/tokens/ledger/setup/icrc1_ledger_setup.mdx
+++ b/docs/developer-docs/defi/tokens/ledger/setup/icrc1_ledger_setup.mdx
@@ -38,7 +38,7 @@ The URL for the ledger Candid file is `https://github.com/dfinity/ic/releases/do
 If you want to make sure you have the latest ICRC-1 ledger files, you can run the following script that downloads the files into your local directory:
 
 ``` sh
-curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/aba60ffbc46acfc8990bf4d5685c1360bd7026b9/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
+curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/69988ae40e4cc0db7ef758da7dd5c0606075e926/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
 chmod +x download_latest_icrc1_ledger.sh
 ./download_latest_icrc1_ledger.sh
 ```


### PR DESCRIPTION
The script that downloads the latest ICRC ledger `wasm` and `did` files was recently updated to download them using [the official ledger releases](https://github.com/dfinity/ic/releases?q=ledger-suite-icrc&expanded=false), rather than the latest commit on the `master` branch of the [ic](https://github.com/dfinity/ic) repository.

The link to the script in the documentation points to a specific commit in the `ic` repository. This PR proposes to update the link to the commit where the script was updated, so that users end up with an officially released ledger.