### PR TITLE
Fix typo in security-best-practices

### DIFF
--- a/docs/developer-docs/security/security-best-practices/misc.mdx
+++ b/docs/developer-docs/security/security-best-practices/misc.mdx
@@ -84,7 +84,7 @@ actor Randomness {
 
 ### 2. Using `raw_rand` as seed for a psuedo random number generator (PRNG)
 
-In this Rust example, we seed the the output from `raw_rand` in a known PRNG like ChaCha20 in the `init` and `post_upgrade` hooks and generate randomness by calling the `random_bytes` method.
+In this Rust example, we seed the output from `raw_rand` in a known PRNG like ChaCha20 in the `init` and `post_upgrade` hooks and generate randomness by calling the `random_bytes` method.
 
 ```rust
 use candid::{CandidType, Principal};


### PR DESCRIPTION
Fixes typo in security-best-practices