### PR TITLE
fix: Update the condition to trigger the workflow that adds the interface-spec label

### DIFF
--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -38,7 +38,7 @@ jobs:
         ./didc check docs/references/_attachments/ic.did
   interface-spec-tag:
     name: Tag PR with interface-spec
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
https://github.com/dfinity/portal/pull/5243 updated the trigger condition for the entire `interface-spec` workflow but forgot to update the trigger condition for the sub-workflow of adding the tag. This PR fixes it.