### PR TITLE
Update 1.3-first-dapp.mdx - npm install not needed

### DIFF
--- a/docs/tutorials/developer-liftoff/level-1/1.3-first-dapp.mdx
+++ b/docs/tutorials/developer-liftoff/level-1/1.3-first-dapp.mdx
@@ -459,13 +459,8 @@ dfx start --clean --background
 Then, you can deploy the dapp with the command:
 
 ```bash
-npm install
 dfx deploy
 ```
-
-:::caution
-If you receive an error related to a missing package, try using this [package.json](https://github.com/jessiemongeon1/dev-journey-poll-dapp/blob/main/package.json) file.
-:::
 
 You may recall that in the previous module, [exploring a live demo](/docs/current/tutorials/developer-liftoff/level-1/1.1-live-demo), you used the `--playground` flag to deploy your canister to the playground network. In this module, you aren't using any flags, which defaults to deploying the canister to the local environment. You can also specify this with the flag `--network local`.
 


### PR DESCRIPTION
In this tutorial we create the dfx project without frontend. In the interactive cli tool the choice is `> no frontend` and otherwise it has been suggested to use the flag `--no-frontend`. No package.json therefore has been created, and we don't need `npm install` that would just throw an error.

Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [ ] Follows the [developer docs style guide](style-guide.md).
- [ ] Follows the [best practices and guidelines](README.md#best-practices).
- [ ] New documentation pages include [document tags](README.md#document-tags).
- [ ] New documentation pages include [SEO keywords](README#seo-keywords).
- [ ] New documents are in the `.mdx` file format to support the previous two components. 
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [ ] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
