### PR TITLE
Update 2.4-intro-candid.mdx - update location candid files

### DIFF
--- a/docs/tutorials/developer-liftoff/level-2/2.4-intro-candid.mdx
+++ b/docs/tutorials/developer-liftoff/level-2/2.4-intro-candid.mdx
@@ -276,9 +276,9 @@ Save this file. Then, compile and deploy the project with the command:
 dfx deploy
 ```
 
-Recall that the Motoko compiler will automatically generate the Candid service description file based on this code. This Candid file can be found at `src/declarations/candid_example_backend/candid_example_backend.did` and will contain the following:
+Recall that the Motoko compiler will automatically generate the Candid service description file based on this code. This Candid file can be found at `.dfx/local/candid_example_backend/candid_example_backend.did` and will contain the following:
 
-```candid title="src/declarations/candid_example_backend/candid_example_backend.did"
+```candid title=".dfx/local/candid_example_backend/candid_example_backend.did"
 service : {
   add: (nat) -> ();
   get: () -> (int) query;


### PR DESCRIPTION
This is the location on my machine, after following the instructions. Is it maybe because it was deployed locally?

<img width="347" alt="image" src="https://github.com/user-attachments/assets/760a27ec-4737-4616-aca3-0967338bd2b1" />


Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a Pull Request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [ ] Follows the [developer docs style guide](style-guide.md).
- [ ] Follows the [best practices and guidelines](README.md#best-practices).
- [ ] New documentation pages include [document tags](README.md#document-tags).
- [ ] New documentation pages include [SEO keywords](README#seo-keywords).
- [ ] New documents are in the `.mdx` file format to support the previous two components. 
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [ ] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
  filled with new documents that you added. This way we can ensure that future Pull Requests are reviewed by the right people.
