### PR TITLE
chore: Remove warning that Bitcoin testnet canister is disabled & fix links

### DIFF
--- a/docs/developer-docs/multi-chain/bitcoin/using-btc/btc-dev-workflow.mdx
+++ b/docs/developer-docs/multi-chain/bitcoin/using-btc/btc-dev-workflow.mdx
@@ -33,9 +33,9 @@ The Bitcoin Testnet API is currently disabled and the ckTestBTC minter canister 
 
 3. [Sign a transaction](sign-transactions.mdx): Next, the transaction must be signed with tECDSA using the `sign_with_ecdsa` API endpoint of the [management canister](/docs/current/developer-docs/smart-contracts/advanced-features/management-canister#signing-and-submitting-bitcoin-transactions). Transactions cannot be sent to the Bitcoin network until they are signed.
 
-4. [Submit a transaction](submit-transactions.mdx): Once a transaction has been signed, it can be submitted to the Bitcoin network to be executed using the Bitcoin API's [`bitcoin_send_transaction`](/docs/current/references/ic-interface-spec#ic-bitcoin_send_transaction) endpoint, which must specify a `blob` of a Bitcoin transaction and a Bitcoin network (mainnet or testnet).
+4. [Submit a transaction](submit-transactions.mdx): Once a transaction has been signed, it can be submitted to the Bitcoin network to be executed using the Bitcoin API's [`bitcoin_send_transaction`](https://github.com/dfinity/bitcoin-canister/blob/master/INTERFACE_SPECIFICATION.md#bitcoin_send_transaction) endpoint, which must specify a `blob` of a Bitcoin transaction and a Bitcoin network (mainnet or testnet).
 
-5. [Read information from the Bitcoin network](read-state.mdx): Lastly, you can query and return information from the Bitcoin network, such as unspent transaction outputs (UTXOs) of a Bitcoin address, the balance of a Bitcoin address, and the percentiles of the fees for the last 10_000 transactions. The endpoints for each query can be found in the [Bitcoin API specification](/docs/current/references/ic-interface-spec#ic-bitcoin-api).
+5. [Read information from the Bitcoin network](read-state.mdx): Lastly, you can query and return information from the Bitcoin network, such as unspent transaction outputs (UTXOs) of a Bitcoin address, the balance of a Bitcoin address, and the percentiles of the fees for the last 10_000 transactions. The endpoints for each query can be found in the [Bitcoin API specification](https://github.com/dfinity/bitcoin-canister/blob/master/INTERFACE_SPECIFICATION.md).
 
 Each of these API endpoints can be executed programmatically within a smart contract that is deployed on ICP. View the documentation for each workflow step to see code examples for interacting with each API endpoint.
 

--- a/docs/developer-docs/multi-chain/bitcoin/using-btc/local-development.mdx
+++ b/docs/developer-docs/multi-chain/bitcoin/using-btc/local-development.mdx
@@ -16,16 +16,8 @@ In this guide, you'll explore how you can develop and test a Bitcoin dapp
 locally. Testing locally allows you to iterate and improve your dapp more quickly.
 
 `dfx` includes support for both the [ECDSA API](/docs/current/references/ic-interface-spec#ic-ecdsa_public_key) and
-the [Bitcoin API](/docs/current/references/ic-interface-spec#ic-bitcoin-api)
+the [Bitcoin API](https://github.com/dfinity/bitcoin-canister/blob/master/INTERFACE_SPECIFICATION.md)
 so that you can locally test out your dapp before deploying it to the Internet Computer.
-
-:::danger
-
-The Bitcoin Testnet API is currently disabled and the ckTestBTC minter canister has been stopped. This is temporary and they will be re-enabled in the future.
-
-[Learn more](https://forum.dfinity.org/t/direct-integration-with-bitcoin/6147/745).
-
-:::
 
 ## Setting up a local Bitcoin network
 


### PR DESCRIPTION
Since the Bitcoin testnet canister is up and running again, the warning that it is currently disabled can be removed.

Moreover, since the Bitcoin API in the management canister is being deprecated, links should point to the interface specification in the Bitcoin canister repository.