### PR TITLE
Update reverse-gas.tsx link to ICPSwap

### DIFF
--- a/src/pages/capabilities/reverse-gas.tsx
+++ b/src/pages/capabilities/reverse-gas.tsx
@@ -214,7 +214,7 @@ function ReverseGasModelPage(): JSX.Element {
               </Link>{" "}
               or{" "}
               <Link
-                href="https://3pbcj-viaaa-aaaah-qaajq-cai.raw.ic0.app/"
+                href="https://app.icpswap.com/swap/pro?input=ryjl3-tyaaa-aaaaa-aaaba-cai&output=aanaa-xaaaa-aaaah-aaeiq-cai"
                 className="link-subtle"
               >
                 ICPSwap


### PR DESCRIPTION
Replaces the canister id raw link to the ICPSwap home page with a friendly domain link to the swap page.