### PR TITLE
point to to imperative Map contribution instead of functional (pure) map

### DIFF
--- a/blog/features/new-motoko-base.md
+++ b/blog/features/new-motoko-base.md
@@ -97,27 +97,27 @@ persistent actor {
 We also included an efficient [stable BTree map implementation](https://github.com/canscale/StableHeapBTreeMap) (big thanks to [Byron Becker](https://github.com/ByronBecker)):
 
 ```motoko no-repl
-import PureMap "mo:base/pure/Map";
+import Map "mo:base/Map";
 import Text "mo:base/Text";
 import Array "mo:base/Array";
 
 persistent actor {
-  var map = PureMap.empty<Text, Nat>();
-  map := PureMap.add(map, Text.compare, "key", 123);
-  assert PureMap.size(map) == 1;
-  assert Array.fromIter(PureMap.entries(map)) == [("key", 123)];
+  let map = Map.empty<Text, Nat>();
+  Map.add(map, Text.compare, "key", 123);
+  Map.size(map) == 1;
+  Array.fromIter(Map.entries(map)) == [("key", 123)];
 }
 ```
 
 Here's the complete list of data structures in the new base library:
 
 * `List` (adapted from [`vector`](https://mops.one/vector) Mops package)
-* `Map`
+* `Map` (adapted from [`StableHeapBTreeMap`](https://mops.one/stableheapbtreemap) Mops package)
 * `Queue`
 * `Set`
 * `Stack`
 * `pure/List`
-* `pure/Map` (adapted from [`StableHeapBTreeMap`](https://mops.one/stableheapbtreemap) Mops package)
+* `pure/Map`
 * `pure/Queue`
 * `pure/Set`
 


### PR DESCRIPTION
In the https://internetcomputer.org/blog/features/new-motoko-base announcement, the post references the adapted StableHeapBTreeMap data structure as a functional (pure implementation), but it’s actually an imperative implementation.

Here’s the imperative implementation of Map for reference.
https://github.com/dfinity/new-motoko-base/blob/35f2ce2580f089c925d768452043c4ed25ee8847/src/Map.mo#L24

I've updated this in the post.
