### PR TITLE
docs: add new typescript example to agent page

### DIFF
--- a/src/components/Ai/CodeSnippetMultipleMessages.tsx
+++ b/src/components/Ai/CodeSnippetMultipleMessages.tsx
@@ -7,20 +7,19 @@ import CodeBlockString from "@site/src/theme/CodeBlock/Content/String";
 const codeSnippets: Record<string, string> = {
   motoko: `import LLM "mo:llm";
 
-  await LLM.chat(#Llama3_1_8B, [
-    {
-      role = #system_;
-      content = "You are a helpful assistant.";
-    },
-    {
-      role = #user;
-      content = "How big is the sun?";
-    }
-  ]);
-  `,
+await LLM.chat(#Llama3_1_8B, [
+  {
+    role = #system_;
+    content = "You are a helpful assistant.";
+  },
+  {
+    role = #user;
+    content = "How big is the sun?";
+  }
+]);`,
   rust: `use ic_llm::{Model, ChatMessage, Role};
 
-  ic_llm::chat(
+ic_llm::chat(
   Model::Llama3_1_8B,
   vec![
       ChatMessage {
@@ -32,9 +31,20 @@ const codeSnippets: Record<string, string> = {
           content: "How big is the sun?".to_string(),
       },
   ],
-  )
-  .await;
-  `,
+)
+.await;`,
+  typescript: `import * as llm from "@dfinity/llm";
+
+await llm.chat(llm.Model.Llama3_1_8B, [
+  {
+    content: "You are a helpful assistant.",
+    role: llm.Role.System,
+  },
+  {
+    content: "How big is the sun?",
+    role: llm.Role.User,
+  }
+]);`
 };
 
 const customStyles = {
@@ -65,6 +75,15 @@ export function CodeSnippetMultipleMessages() {
                 showLineNumbers={true}
               >
                 {codeSnippets.motoko}
+              </CodeBlockString>
+            </TabItem>
+            <TabItem value="typescript" label="Typescript" default>
+              <CodeBlockString
+                language="typescript"
+                className="text-left"
+                showLineNumbers={true}
+              >
+                {codeSnippets.typescript}
               </CodeBlockString>
             </TabItem>
             <TabItem value="rust" label="Rust">

--- a/src/components/Ai/CodeSnippetPrompting.tsx
+++ b/src/components/Ai/CodeSnippetPrompting.tsx
@@ -7,12 +7,13 @@ import CodeBlockString from "@site/src/theme/CodeBlock/Content/String";
 const codeSnippets: Record<string, string> = {
   motoko: `import LLM "mo:llm";
 
-await LLM.prompt(#Llama3_1_8B, "What's the speed of light?")
-  `,
+await LLM.prompt(#Llama3_1_8B, "What's the speed of light?")`,
+  typescript: `import * as llm from "@dfinity/llm";
+
+await llm.prompt(llm.Model.Llama3_1_8B, "What's the speed of light?");`,
   rust: `use ic_llm::Model;
 
-ic_llm::prompt(Model::Llama3_1_8B, "What's the speed of light?").await;
-  `,
+ic_llm::prompt(Model::Llama3_1_8B, "What's the speed of light?").await;`,
 };
 
 const customStyles = {
@@ -43,6 +44,15 @@ export function CodeSnippetPrompting() {
                 showLineNumbers={true}
               >
                 {codeSnippets.motoko}
+              </CodeBlockString>
+            </TabItem>
+            <TabItem value="typescript" label="Typescript" default>
+              <CodeBlockString
+                language="motoko"
+                className="text-left"
+                showLineNumbers={true}
+              >
+                {codeSnippets.typescript}
               </CodeBlockString>
             </TabItem>
             <TabItem value="rust" label="Rust">


### PR DESCRIPTION
Adds typescript examples to the AI agent page.

<img width="1141" alt="grafik" src="https://github.com/user-attachments/assets/c51fa19b-929b-4623-804d-d9cc7b76d3b8" />
