### PR TITLE
chore: Fix ordering in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,11 +14,11 @@ submodules/sdk @dfinity/sdk
 # Motoko
 submodules/motoko @dfinity/languages
 
-# Cross chain
-docs/defi/chain-key-tokens/ @dfinity/cross-chain-team
-
 # FI
 docs/defi/ @dfinity/finint
+
+# Cross chain
+docs/defi/chain-key-tokens/ @dfinity/cross-chain-team
 
 # ProdSec
 docs/building-apps/best-practices/security/ @dfinity/product-security


### PR DESCRIPTION
The recent change to add the cross chain team as codeowners of `docs/defi/chain-key-tokens/`, while keeping the FI team as the owners of everything else under `docs/defi/` didn't seem to work due to incorrect ordering of the rules (see e.g., [this PR](https://github.com/dfinity/portal/pull/5602) where reviews are requested from the FI team, but not the cross chain team).