### PR TITLE
Revert "feat: Specify a hard lower limit for canister's freezing threshold (#5489)"

### DIFF
--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,11 @@
 ## Changelog {#changelog}
 
+### 0.38.0 (2025-04-18) {#0_38_0}
+* Reverted a lower bound of one week on the canister's freezing threshold.
+
+### 0.37.0 (2025-04-11) {#0_37_0}
+* Introduced a lower bound of one week on the canister's freezing threshold.
+
 ### 0.36.0 (2025-03-31) {#0_36_0}
 * Bounded-wait calls.
 

--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,8 +1,5 @@
 ## Changelog {#changelog}
 
-### 0.37.0 (2025-04-11) {#0_37_0}
-* Introduced a lower bound of one week on the canister's freezing threshold.
-
 ### 0.36.0 (2025-03-31) {#0_36_0}
 * Bounded-wait calls.
 

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -2236,7 +2236,7 @@ The optional `settings` parameter can be used to set the following settings:
 
 -   `freezing_threshold` (`nat`)
 
-    Must be a number between 604800 (or equivalent of 1 week in seconds) and 2<sup>64</sup>-1, inclusively, and indicates a length of time in seconds.
+    Must be a number between 0 and 2<sup>64</sup>-1, inclusively, and indicates a length of time in seconds.
 
     A canister is considered frozen whenever the IC estimates that the canister would be depleted of cycles before `freezing_threshold` seconds pass, given the canister's current size and the IC's current cost for storage.
 


### PR DESCRIPTION
This reverts commit d612c16d4604a0cb55b81da8317a182df7934bbc introducing a lower bound of one week on the freezing threshold of a canister.