### PR TITLE
fix: Fix broken links around cycles-cost-formula page

### DIFF
--- a/docs/building-apps/essentials/gas-cost.mdx
+++ b/docs/building-apps/essentials/gas-cost.mdx
@@ -90,7 +90,7 @@ Setting even 1% compute allocation provides a significant advantage over caniste
 
 Compute is a finite resource and is priced as such. The allocatable compute capacity is 299% per subnet. The current fee for 1% compute allocation per second is 10M cycles (approximately $0.000013 USD). Therefore, a canister that requests 100% compute allocation would be charged 10M \* 100 cycles per second.
 
-[View the cost calculation formula for more information about how costs are calculated](/docs/references/cost-calculation-formulas).
+[View the cost calculation formula for more information about how costs are calculated](/docs/references/cycles-cost-formulas).
 
 ### Storage
 
@@ -124,7 +124,7 @@ A controller of a canister can disable resource reservation by setting the `rese
 
 Certain network features incur a special cost based on the feature’s unique infrastructure and functionality. These features include:
 
-- [**HTTPS outcalls**](/docs/references/cost-calculation-formulas)
+- [**HTTPS outcalls**](/docs/references/cycles-cost-formulas#https-outcalls)
 
 - [**Bitcoin API**](/docs/references/bitcoin-how-it-works)
 

--- a/docs/references/https-outcalls-how-it-works.mdx
+++ b/docs/references/https-outcalls-how-it-works.mdx
@@ -173,7 +173,7 @@ Developers new to the feature are likely to run into certain problems in the beg
 
 ### Pricing
 
-[View the cycles cost for an HTTPS outcall request](/docs/building-apps/essentials/gas-cost#https-outcalls).
+[View the cycles cost for an HTTPS outcall request](/docs/references/cycles-cost-formulas#https-outcalls).
 The cycles provided with the call must be sufficient for covering the cost of the request; excessive cycles are returned to the caller.
 
 The current pricing is defined to be rather conservative (expensive), and prices may change in the future with the introduction of an update of the pricing model. However, note that an HTTPS outcall with a small response, like the ones used for querying financial APIs, only costs fractions of a USD cent, which is substantially cheaper than fees charged for a call by oracles on most blockchains.


### PR DESCRIPTION
This PR fixes 3 now broken links.

- Two links were referring to the correct document, however used wrong naming.
- One link referred to a page that no longer contained the relevant information and was updated as well.