### PR TITLE
chore: note on reserved cycles after setting memory allocation

### DIFF
--- a/docs/building-apps/canister-management/storage.mdx
+++ b/docs/building-apps/canister-management/storage.mdx
@@ -21,11 +21,11 @@ Heap memory is limited to a maximum of 4GiB of data.
 
 ## Stable memory
 
-Stable memory is a feature unique to the Internet Computer Protocol that provides a long-term, persistent data storage option separate from a canister's heap memory. Unless a canister is reinstalled or its data is cleared due to cycle depletion, the data stored in stable memory is not cleared or removed. The stable memory is preserved throughout the process, while any other WebAssembly state is discarded.
+Stable memory is a feature unique to the Internet Computer Protocol that provides a long-term, persistent data storage option separate from a canister's heap memory. Unless a canister is reinstalled, uninstalled, or its data is cleared due to cycle depletion, the data stored in stable memory is not cleared or removed. The stable memory is preserved throughout the process, while any other WebAssembly state is discarded.
 
 To use stable memory, you must anticipate which portions of the canister's data you want to persist across upgrades by indicating this within the canister code. More information about this can be found in the section below, [Storage handling in different languages](#storage-handling-in-different-languages).
 
-By default, a canister's stable memory is empty. The maximum storage limit for stable memory is 500GiB if the <GlossaryTooltip>subnet</GlossaryTooltip> the canister is deployed on can accommodate it. If a canister uses more than 500GiB of stable memory, the canister will trap and become unrecoverable.
+By default, a canister's stable memory is empty. The maximum storage limit for stable memory is 500GiB if the <GlossaryTooltip>subnet</GlossaryTooltip> the canister is deployed on can accommodate it.
 
 ## Storage cost
 

--- a/docs/building-apps/essentials/gas-cost.mdx
+++ b/docs/building-apps/essentials/gas-cost.mdx
@@ -94,7 +94,7 @@ Compute is a finite resource and is priced as such. The allocatable compute capa
 
 ### Storage
 
-Canisters pay for the storage used by both their [Wasm memory](/docs/building-apps/canister-management/storage#heap-memory) and [stable memory](/docs/building-apps/canister-management/storage#stable-memory). Cost is calculated based on the amount of storage and length of time, such that storing 1 GiB for 1 second costs 127k cycles, which amounts to \~4T cycles (approximately $5.35 USD) for storing 1 GiB for 1 year.
+Canisters pay for the storage used by both their [Wasm memory](/docs/building-apps/canister-management/storage#heap-memory) and [stable memory](/docs/building-apps/canister-management/storage#stable-memory). Cost is calculated based on the amount of storage and time duration, such that storing 1 GiB for 1 second costs 127k cycles, which amounts to \~4T cycles (approximately $5.35 USD) for storing 1 GiB for 1 year.
 
 Canisters can reserve storage on a subnet through the `memory_allocation` setting. However, the canister will be charged as if the entire amount of allocated storage is being used.
 
@@ -103,13 +103,19 @@ Canisters can reserve storage on a subnet through the `memory_allocation` settin
 
 When a canister allocates new storage bytes, the system moves some number of cycles from the main balance into the canister’s reserved cycles balance to cover future payments for the newly allocated bytes.
 
-Operations that allocate new storage bytes are:
+Operations that potentially allocate new storage bytes are:
 
 - **Wasm instruction**: `memory.grow`.
 
 - **System API calls**: `ic0.stable_grow()` `ic0.stable64_grow()`.
 
 - **Increasing the** `memory_allocation` **in the canister settings.**
+
+- **Installing a new canister WASM.**
+
+- **Taking and loading canister snapshots.**
+
+- **Uploading chunks to the WASM chunk store.**
 
 The reserved cycles are not transferable, and the amount depends on how full the subnet’s memory is.
 
@@ -118,6 +124,12 @@ The reserved cycles are not transferable, and the amount depends on how full the
 - If subnet usage is above `450GiB`, then the amount of reserved cycles per allocated byte grows linearly depending on the subnet usage, from `0` to `10` years worth of payments at the subnet capacity (`1TiB`).
 
 A controller of a canister can disable resource reservation by setting the `reserved_cycles_limit=0` in the canister’s settings. Such opted-out canisters are not able to allocate if the subnet usage is above `450GiB`.
+
+To prevent repeated allocations resulting in repeated increases of the canister’s reserved cycles balance, a memory allocation can be specified in the canister settings.
+This way, the canister will be charged as if the entire amount of allocated storage is being used, but no additional allocations will be performed.
+Hence, the canister’s reserved cycles balance might only increase when setting the memory allocation, but does not increase afterwards.
+The memory allocation must be set to cover the entire memory usage of the canister (Wasm memory, stable memory, snapshots, WASM chunks, installed WASM binary, canister history)
+and the canister’s memory usage cannot exceed its memory allocation while a memory allocation is set.
 
 
 ### Special features


### PR DESCRIPTION
This PR adds a note on using memory allocation to avoid repeated increases of the canister's reserved cycles balance. It also lists further cases causing memory allocations (and potentially increasing the canister's reserved cycles balance) and fixes a few imprecise formulations.