### PR TITLE
fix: out of memory error

### DIFF
--- a/docs/references/execution-errors.mdx
+++ b/docs/references/execution-errors.mdx
@@ -82,11 +82,11 @@ To fix this error, consider installing code using [`dfx deploy`](/docs/building-
 
 
 ### Out of memory
-The canister was tried to request more memory than its allocation allowed during execution, causing the execution to fail.
+The canister was tried to request more memory than available during execution, causing the execution to fail.
 
 An example of this error is:
 ```
-  Canister exceeded its allowed memory allocation.
+  Canister cannot grow its memory usage.
 ```
 
 There are [system-wide limits][limits] on the main and stable memory of each canister, as well as limits on the total memory of a subnet. This error could be triggered by any one of those limits being reached.


### PR DESCRIPTION
This PR fixes the section on out of memory error, based this replica implementation [fix](https://github.com/dfinity/ic/pull/5358) that has been rolled out to the ICP mainnet.