### PR TITLE
Revert "chore: Fix the workflow that adds the interface-spec label (#5243)"

### DIFF
--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -1,6 +1,6 @@
 name: Interface Specification
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - .github/workflows/interface-spec.yml
       - docs/references/http-gateway-protocol-spec.md


### PR DESCRIPTION
The motivation for the revert is that _tests_ should be running on the _feature branch_.