### PR TITLE
Mraszyk/interface spec tag.yml

### DIFF
--- a/.github/workflows/interface-spec-tag.yml
+++ b/.github/workflows/interface-spec-tag.yml
@@ -1,0 +1,23 @@
+name: Interface Specification
+on:
+  pull_request_target:
+    paths:
+      - .github/workflows/interface-spec.yml
+      - docs/references/http-gateway-protocol-spec.md
+      - docs/references/ic-interface-spec.md
+      - docs/references/_attachments/certificates.cddl
+      - docs/references/_attachments/http-gateway.did
+      - docs/references/_attachments/ic.did
+      - docs/references/_attachments/interface-spec-changelog.md
+      - docs/references/_attachments/requests.cddl
+jobs:
+  interface-spec-tag:
+    name: Tag PR with interface-spec
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Tag PR with interface-spec
+      run: |
+        gh pr edit ${{ github.event.pull_request.number }} --add-label interface-spec
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -1,6 +1,6 @@
 name: Interface Specification
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - .github/workflows/interface-spec.yml
       - docs/references/http-gateway-protocol-spec.md

--- a/.github/workflows/interface-spec.yml
+++ b/.github/workflows/interface-spec.yml
@@ -36,15 +36,3 @@ jobs:
         chmod +x didc
         ./didc check docs/references/_attachments/http-gateway.did
         ./didc check docs/references/_attachments/ic.did
-  interface-spec-tag:
-    name: Tag PR with interface-spec
-    if: ${{ github.event_name == 'pull_request_target' }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Tag PR with interface-spec
-      run: |
-        gh pr edit ${{ github.event.pull_request.number }} --add-label interface-spec
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR reverts #5243 and introduces a separate workflow for tagging Interface Specification PRs. The motivation for the revert is that tests should be running on the feature branch.