### PR TITLE
Typo in nodejs agent doc

### DIFF
--- a/docs/building-apps/interact-with-canisters/agents/nodejs.mdx
+++ b/docs/building-apps/interact-with-canisters/agents/nodejs.mdx
@@ -44,7 +44,7 @@ ICP doesn't natively support WebSockets, though the external package [ic-websock
 You can install this package with the command:
 
 ```
-npm install --save ic-websocket-sdk
+npm install --save ic-websocket-js
 ```
 
 If your project uses any `@dfinity/…` package, it is recommended to use version `v0.20.1` or newer.


### PR DESCRIPTION
Fix typo in the WebSockets section. Library should be `ic-websocket-js` instead of `ic-websocket-sdk`
