### PR TITLE
chore(rosetta): improve rosettas' run guide

### DIFF
--- a/docs/defi/rosetta/icp_rosetta/index.mdx
+++ b/docs/defi/rosetta/icp_rosetta/index.mdx
@@ -10,142 +10,126 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 ICP Rosetta allows for communication with the [ICP ledger](https://dashboard.internetcomputer.org/canister/ryjl3-tyaaa-aaaaa-aaaba-cai) and the [NNS governance canister](https://dashboard.internetcomputer.org/canister/rrkah-fqaaa-aaaaa-aaaaq-cai) through the Rosetta-API standard.
 
-## Set up an ICP Rosetta node
+## Overview
 
-You can set up a Rosetta API-compliant node to interact with the Internet Computer and interact with ICP tokens. To keep the instructions simple, you can use a Docker image to create the integration with the Rosetta API. You can also build and run the binary using the source code.
+The Rosetta API is a standardized specification for blockchain integrations developed by Coinbase. ICP Rosetta provides a Rosetta-compliant interface that enables:
 
-If you don’t already have [Docker](https://docs.docker.com/get-docker/) on your computer, download and install the latest version.
+- **Custody platforms** to integrate with the Internet Computer Protocol
+- **Analytics and compliance tools** to pull ledger and governance data
+- **KYC (Know Your Customer)** and **AML (Anti-Money Laundering)** compliance
+- **Transaction preparation and submission** to the ICP ledger and NNS governance
 
-Then, to set up a Rosetta node (which connects to a testnet):
+## Supported operations
 
-### Step 1: [Install Docker](https://docs.docker.com/get-docker/) and [start the Docker daemon](https://docs.docker.com/config/daemon/).
+ICP Rosetta supports various operations through its APIs:
 
-The Docker daemon (`dockerd`) should automatically start when you reboot your computer. If you start the Docker daemon manually, the instructions vary depending on the local operating system.
+### Ledger operations
+- Account balance queries
+- Transaction history retrieval
+- Transaction construction and submission
+- Transfer operations
 
-### Step 2:  Pull the latest `dfinity/rosetta-api` image from the Docker Hub.
+### Governance operations
+- Neuron management (stake, dissolve, spawn)
+- Voting on governance proposals
+- Reward distribution queries
+- Network nervous system interactions
 
-Run the following command:
+### Supported endpoints
 
-``` bash
-docker pull dfinity/rosetta-api
-```
+ICP Rosetta implements the complete Rosetta specification including:
 
-### Step 3:  Start the integration software.
+- **Data API**: For querying blockchain data
+- **Construction API**: For creating and submitting transactions
+- **Network API**: For network information and status
 
-Run the following command:
+## Getting started
 
-``` bash
-docker run \
-    --interactive \
-    --tty \
-    --publish 8081:8081 \
-    --rm \
-    dfinity/rosetta-api
-```
+To start using ICP Rosetta, you'll need to set up a Rosetta node. There are multiple deployment options available:
 
-This command starts the software on the local host and displays output similar to the following:
+- **Docker deployment** (recommended for most users)
+- **Building from source** (for development and customization)
+- **Local cluster setup** (for testing with monitoring tools)
+- **Managed endpoints** (no local setup required)
 
-```
-Listening on 0.0.0.0:8081
-Starting Rosetta API server
-```
+### Test environment
 
-By default, the software connects to a testnet.
-It **does not** connect to the ledger canister running on the Internet Computer blockchain mainnet.
+For testing and development, you can connect to the test ICP ledger (`xafvr-biaaa-aaaai-aql5q-cai`) that runs on mainnet but uses test tokens (TESTICP). Get free test tokens from [Validation Cloud's faucet](https://docs.validationcloud.io/v1/about/faucets) to start experimenting without using real ICP.
 
-If you have been assigned a test network and corresponding ledger canister identifier, you can run the command against that network by specifying an additional `canister` argument.
-For example, the following command illustrates connecting to the ledger canister on a test network by setting the `canister` argument to `2xh5f-viaaa-aaaab-aae3q-cai`.
-
-``` bash
-docker run \
-    --interactive \
-    --tty \
-    --publish 8081:8081 \
-    --rm \
-    dfinity/rosetta-api \
-    --canister 2xh5f-viaaa-aaaab-aae3q-cai
-```
-
-:::info
-The first time you run the command, it might take some time for the node to catch up to the current tip of the chain.
-When the node is caught up, you should see output similar to the following:
-
-You are all caught up to block height 109
-:::
-
-After completing this step, the node continues to run as a **passive** node that does not participate in block making.
-
-### Step 4:  Open a new terminal window or tab and run the `ps` command to verify the status of the service.
-
-If you need to stop the service, press <kbd>Ctrl-C</kbd>. You might want to do this to change the canister identifier you are using, for example.
-
-To test the integration after setting up the node, you will need to write a program to simulate a principal submitting a transaction or looking up an account balance.
-
-## Run the Rosetta node in production
-
-When you are finished testing, you should run the Docker image in production mode without the `--interactive`, `--tty`, and `--rm` command-line options.
-These command-line options are used to attach an interactive terminal session and remove the container and are primarily intended for testing purposes.
-To run the software in a production environment, you can start the Docker image using the `--detach` option to run the container in the background and, optionally, specify the `--volume` command for storing blocks.
-
-To connect the Rosetta node instance to the mainnet, add flags: `--mainnet` and `--not-whitelisted`. The flag for whitelisting is reserved for certain IP addresses that need to connect to permissioned testnets.
-
-For more information about Docker command-line options, see the [Docker reference documentation](https://docs.docker.com/engine/reference/commandline/run/).
+For detailed setup instructions, see the [Running Rosetta](./running-rosetta) guide.
 
 ## Requirements and limitations
 
-The integration software provided in the Docker image has one requirement that is not part of the standard Rosetta API specification.
+The integration software provided has specific requirements and limitations:
 
-For transactions involving ICP tokens, the unsigned transaction must be created less than 24 hours before the network receives the signed transaction.
-The reason for this is the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication).
-Any submitted transaction that refers back to a too old transaction is rejected to maintain operational efficiency.
+### Transaction timing requirement
 
-Other than this requirement, the Rosetta API integration software fully complies with all standard Rosetta endpoints and passes all of the `rosetta-cli` tests.
-The software can accept any valid Rosetta request.
-However, the integration software only prompts for transactions to be signed using Ed25519 and SECP256k1, rather than all the [signature schemes listed](https://www.rosetta-api.org/docs/models/SignatureType.html#values), and only replies with a small subset of the potential responses that the specification supports.
-For example, the software doesn’t implement any of the UTXO features of Rosetta, so you won’t see any UTXO messages in any of the software responses.
+For transactions involving ICP tokens, the unsigned transaction must be created less than 24 hours before the network receives the signed transaction. This is due to the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication). Any submitted transaction that refers back to a transaction older than 24 hours is rejected to maintain operational efficiency.
+
+### Signature schemes
+
+The examples and documentation typically use:
+- **Ed25519** 
+- **SECP256k1**
+
+For the complete list of supported signature schemes, refer to the [Rosetta specification](https://www.rosetta-api.org/docs/models/SignatureType.html#values).
+
+### Response format
+
+The integration software only replies with a subset of the potential responses that the specification supports. For example:
+- No UTXO features are implemented
+- No UTXO messages appear in any software responses
+
+### Compliance
+
+Other than the 24-hour transaction timing requirement, the Rosetta API integration software:
+- ✅ Fully complies with all standard Rosetta endpoints
+- ✅ Passes all `rosetta-cli` tests
+- ✅ Accepts any valid Rosetta request
 
 ## Frequently asked questions
 
-The following questions come from the most commonly reported questions and blockers from the developer community regarding Rosetta integration with the Internet Computer.
+### How do I run an instance of the Rosetta node?
 
-#### How do I run an instance of the Rosetta node?
+The easiest way is to use the [`dfinity/rosetta-api`](https://hub.docker.com/r/dfinity/rosetta-api/tags?page=1&ordering=last_updated) Docker image. See the [Running Rosetta](./running-rosetta) guide for detailed instructions on all deployment methods.
 
-An easy way to accomplish this is to use the [`dfinity/rosetta-api`](https://hub.docker.com/r/dfinity/rosetta-api/tags?page=1&ordering=last_updated) Docker image.
-Once the node initializes and syncs all blocks, you can perform queries and submit transactions by invoking the Rosetta API on the node.
-The node listens on the `8081` port.
+### How do I connect the Rosetta node to the mainnet?
 
-#### How do I connect the Rosetta node to the mainnet?
+Use the flags `--mainnet` and `--not-whitelisted` when starting your Rosetta node.
 
-Use flags `--mainnet` and `--not-whitelisted`
+### How do I know if the node has caught up with the network?
 
-#### How do I know if the node has caught up with the test net?
+Look for the log entry: `You are all caught up to block XX` in the startup logs after `Starting Rosetta API server`. This confirms synchronization with all blocks.
 
-Search the `Starting Rosetta API server` startup log. There will be a log entry that says, `You are all caught up to block XX`.
-This message confirms that you are caught up with all blocks.
+### How do I persist synced block data?
 
-#### How to persist synced blocks data?
-Mount the `/data` directory as a [volume](https://docs.docker.com/storage/volumes/).
+Mount the `/data` directory as a Docker volume:
 
 ```bash
 docker volume create rosetta
-```
-```bash
 docker run \
-    --volume rosetta:/data \
-    --interactive \
-    --tty \
-    --publish 8081:8081 \
-    --rm \
-   dfinity/rosetta-api
+    --volume rosetta:/data \
+    --publish 8081:8081 \
+    --detach \
+    dfinity/rosetta-api
 ```
 
-#### Is the Rosetta node versioned?
-Yes, new versions are regularly published on [DockerHub](https://hub.docker.com/r/dfinity/rosetta-api/tags).
-It is recommended to use a specific version in production settings, e.g., `dfinity/rosetta-api:v2.0.0`.
-You can query the version of a running Rosetta node using the `/network/options` endpoint.
+### Is the Rosetta node versioned?
+
+Yes, new versions are regularly published on [DockerHub](https://hub.docker.com/r/dfinity/rosetta-api/tags). It's recommended to use specific versions in production (e.g., `dfinity/rosetta-api:v2.0.0`).
+
+You can query the version of a running node using the `/network/options` endpoint:
 
 ```bash
-$ curl -s -q -H 'Content-Type: application/json' -d '{"network_identifier": {"blockchain": "Internet Computer", "network": "00000000000000020101"}}' -X POST http://localhost:8080/network/options | jq '.version.node_version'
-
-"2.0.0"
+curl -H 'Content-Type: application/json' \
+  -d '{"network_identifier": {"blockchain": "Internet Computer", "network": "00000000000000020101"}}' \
+  -X POST http://localhost:8081/network/options | jq '.version.node_version'
 ```
+
+### What's the default port?
+
+The Rosetta node listens on port **8081** by default.
+
+### How do I get test tokens for development?
+
+Use [Validation Cloud's free faucet](https://docs.validationcloud.io/v1/about/faucets) to get TESTICP tokens from the test ICP ledger (`xafvr-biaaa-aaaai-aql5q-cai`). This allows you to test ICP Rosetta functionality without using real ICP tokens.

--- a/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
+++ b/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
@@ -1,0 +1,277 @@
+---
+keywords: [intermediate, rosetta, tutorial, docker, source, local cluster, validation cloud, deployment]
+---
+
+import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
+
+# Running ICP Rosetta
+
+<MarkdownChipRow labels={["Intermediate", "Rosetta"]} />
+
+There are several ways to run ICP Rosetta depending on your use case and requirements. This guide covers all available deployment methods.
+
+## Docker (Recommended)
+
+The easiest way to run ICP Rosetta is using the official Docker image. This method is recommended for most users.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- [Docker daemon](https://docs.docker.com/config/daemon/) started
+
+### Step 1: Pull the latest image
+
+```bash
+docker pull dfinity/rosetta-api
+```
+
+### Step 2: Run the container
+
+For the **test ICP ledger** on mainnet (recommended for testing):
+
+```bash
+docker run \
+    --interactive \
+    --tty \
+    --publish 8081:8081 \
+    --rm \
+    dfinity/rosetta-api \
+    --canister-id xafvr-biaaa-aaaai-aql5q-cai \
+    --token-sybol TESTICP \
+    --mainnet \
+    --not-whitelisted
+```
+
+For the **official ICP ledger** on mainnet:
+
+```bash
+docker run \
+    --interactive \
+    --tty \
+    --publish 8081:8081 \
+    --rm \
+    dfinity/rosetta-api \
+    --mainnet \
+    --not-whitelisted
+```
+
+:::info
+To get TESTICP tokens for testing, you can use [Validation Cloud's free faucet](https://docs.validationcloud.io/v1/about/faucets). This provides test tokens without needing to use real ICP on mainnet.
+:::
+
+For a specific **test ledger canister**:
+
+```bash
+docker run \
+    --interactive \
+    --tty \
+    --publish 8081:8081 \
+    --rm \
+    dfinity/rosetta-api \
+    --canister 2xh5f-viaaa-aaaab-aae3q-cai
+```
+
+### Step 3: Production deployment
+
+For production environments, run without interactive flags and optionally persist data:
+
+```bash
+# Create a volume for data persistence
+docker volume create rosetta
+
+# Run in production mode
+docker run \
+    --volume rosetta:/data \
+    --publish 8081:8081 \
+    --detach \
+    dfinity/rosetta-api \
+    --mainnet \
+    --not-whitelisted
+```
+
+### Docker versioning
+
+It's recommended to use specific versions in production:
+
+```bash
+docker run \
+    --publish 8081:8081 \
+    --detach \
+    dfinity/rosetta-api:v2.0.0 \
+    --mainnet \
+    --not-whitelisted
+```
+
+Check available versions on [DockerHub](https://hub.docker.com/r/dfinity/rosetta-api/tags).
+
+## From Source
+
+You can build and run ICP Rosetta directly from the Internet Computer source code.
+
+### Prerequisites
+
+- [Bazel](https://bazel.build/) build system
+- Internet Computer repository cloned locally
+
+### Building and running
+
+```bash
+# Clone the IC repository (if not already done)
+git clone https://github.com/dfinity/ic.git
+cd ic
+
+# Build and run ICP Rosetta
+bazel run //rs/rosetta-api/icp:ic-rosetta-api -- \
+    --port 8081 \
+    --mainnet \
+    --not-whitelisted \
+    --store-location /tmp
+```
+
+:::info
+The `--store-location` parameter is important when running from source as it specifies where the database files will be stored. Without this parameter, the default location may not be writable or accessible.
+:::
+
+This method gives you the latest development version and allows for custom modifications.
+
+## Local Cluster
+
+For development and testing purposes, you can set up a complete local Kubernetes cluster with monitoring tools.
+
+### Overview
+
+The local cluster setup provides:
+- Minikube-based Kubernetes cluster
+- Prometheus and Grafana for monitoring
+- cAdvisor for container metrics
+- Both ICP and ICRC1 Rosetta services
+
+### Prerequisites
+
+The deployment script will help install missing dependencies:
+- Docker
+- Minikube
+- kubectl
+- Helm
+
+### Deploying production images
+
+```bash
+# Clone the IC repository
+git clone https://github.com/dfinity/ic.git
+cd ic/rs/rosetta-api/local/cluster
+
+# Deploy with default test ledgers
+./deploy.sh
+
+# Deploy pointing to specific ledgers
+./deploy.sh \
+    --icp-ledger xafvr-biaaa-aaaai-aql5q-cai \
+    --icp-symbol TESTICP \
+    --icrc1-ledger 3jkp5-oyaaa-aaaaj-azwqa-cai
+```
+
+### Deploying local images
+
+First, build the containers from within the dev container:
+
+```bash
+# Enter dev container
+./ci/container/container-run.sh
+
+# Build ICP Rosetta
+bazel build //rs/rosetta-api/icp:rosetta_image.tar
+mv bazel-bin/rs/rosetta-api/icp/rosetta_image.tar /tmp
+
+# Build ICRC1 Rosetta
+bazel build //rs/rosetta-api/icrc1:icrc_rosetta_image.tar
+mv bazel-bin/rs/rosetta-api/icrc1/icrc_rosetta_image.tar /tmp
+
+# Exit dev container
+exit
+```
+
+Then deploy the local images:
+
+```bash
+./deploy.sh \
+    --local-icp-image-tar /tmp/rosetta_image.tar \
+    --local-icrc1-image-tar /tmp/icrc_rosetta_image.tar
+```
+
+### Monitoring with Grafana
+
+Access Grafana at `http://localhost:3000` with:
+- Username: `admin`
+- Password: `admin`
+
+Import the dashboard using the `rosetta_load_dashboard.json` file in the cluster directory.
+
+### Cleaning up
+
+To start fresh:
+
+```bash
+./deploy.sh --clean
+```
+
+## Validation Cloud
+
+For those who prefer not to run Rosetta locally, Validation Cloud offers managed ICP Rosetta endpoints that you can use for learning, development, and production.
+
+### Features
+
+- Managed infrastructure (no local setup required)
+- Global distribution with multi-region support
+- 99.99% uptime SLA
+- 24/7 customer support
+- SOC 2 Type 2 compliance
+
+### Getting started
+
+1. Visit [Validation Cloud ICP page](https://www.validationcloud.io/icp)
+2. Sign up for an account
+3. Choose between Free tier (50M Compute Units) or Scale plan (unlimited)
+4. Get your API endpoint and start building
+
+### Supported APIs
+
+- ICP Rosetta nodes for ledger communication
+- ICRC API for token interactions
+- Access to NNS governance canister
+
+This option is useful for:
+- Quick prototyping and learning
+- Development without local infrastructure setup
+- Production applications that prefer managed services
+
+## Verification and testing
+
+Regardless of the deployment method, you can verify your Rosetta node is working:
+
+### Check node status
+
+```bash
+curl -H "Content-Type: application/json" \
+  -d '{"network_identifier": {"blockchain": "Internet Computer", "network": "00000000000000020101"}}' \
+  -X POST http://localhost:8081/network/status
+```
+
+### Check version
+
+```bash
+curl -H "Content-Type: application/json" \
+  -d '{"network_identifier": {"blockchain": "Internet Computer", "network": "00000000000000020101"}}' \
+  -X POST http://localhost:8081/network/options | jq '.version.node_version'
+```
+
+### Wait for sync
+
+Look for the message: `You are all caught up to block XX` in the logs to confirm the node is synchronized.
+
+## Requirements and limitations
+
+- **Transaction timing**: Unsigned transactions must be created less than 24 hours before submission due to the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication)
+- **Signature schemes**: Examples typically use Ed25519 and SECP256k1
+- **Port**: Default listening port is 8081
+- **Data persistence**: Mount `/data` directory as a volume for Docker deployments 

--- a/docs/defi/rosetta/icrc_rosetta/index.mdx
+++ b/docs/defi/rosetta/icrc_rosetta/index.mdx
@@ -8,199 +8,193 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 <MarkdownChipRow labels={["Intermediate", "Rosetta" ]} />
 
-The ICRC Rosetta implementation allows for communication with the ICRC-1 compatible ledgers through the [Rosetta-API standard](https://docs.cdp.coinbase.com/mesh/docs/welcome). Examples include the [ckBTC ledger](https://dashboard.internetcomputer.org/canister/mxzaz-hqaaa-aaaar-qaada-cai) and the [ckETH ledger](https://dashboard.internetcomputer.org/canister/ss2fx-dyaaa-aaaar-qacoq-cai).
-This documentation covers the endpoints of the [Data-API](/docs/defi/rosetta/icrc_rosetta/data_api/) and the [Construction-API](/docs/defi/rosetta/icrc_rosetta/construction_api/).
+The ICRC Rosetta implementation allows for communication with ICRC-1 compatible ledgers through the [Rosetta-API standard](https://docs.cdp.coinbase.com/mesh/docs/welcome). Examples include the [ckBTC ledger](https://dashboard.internetcomputer.org/canister/mxzaz-hqaaa-aaaar-qaada-cai) and the [ckETH ledger](https://dashboard.internetcomputer.org/canister/ss2fx-dyaaa-aaaar-qacoq-cai).
 
-## Set up an ICRC Rosetta node
+## Overview
 
-You can set up a Rosetta API-compliant node for ICRC to interact with the Internet Computer and your ICRC-1 ledgers of choice.
-For simplicity, these instructions will describe how to use a Docker image to create the integration with the Rosetta API.
-You can also build and run the binary using the source code.
+The Rosetta API is a standardized specification for blockchain integrations developed by Coinbase. ICRC Rosetta provides a Rosetta-compliant interface specifically designed for ICRC-1 compatible tokens on the Internet Computer Protocol.
 
-If you don’t already have [Docker](https://docs.docker.com/get-docker/) in your environment, download and install the latest version.
+### Key capabilities
 
-### Step 1:  [Install Docker](https://docs.docker.com/get-docker/) and [start the Docker daemon](https://docs.docker.com/config/daemon/).
+ICRC Rosetta enables:
+- **Multi-token support**: Connect to multiple ICRC-1 ledgers simultaneously (v2.1.0+)
+- **Chain-key token integration**: Native support for ckBTC, ckETH, and other chain-key tokens
+- **Custody platform integration**: Standardized interface for wallet and custody providers
+- **Analytics and compliance**: Access to comprehensive transaction and balance data
+- **DeFi application support**: Reliable infrastructure for decentralized finance applications
 
-The Docker daemon (`dockerd`) should automatically start when you reboot your computer. If you start the Docker daemon manually, the instructions vary depending on the local operating system.
+### Supported tokens
 
-### Step 2:  Pull the latest `dfinity/ic-icrc-rosetta-api` image from the Docker Hub.
+ICRC Rosetta works with any ICRC-1 compatible token, including:
 
-Run the following command:
+#### Production tokens (mainnet)
+- **ckBTC** (Chain-key Bitcoin): `mxzaz-hqaaa-aaaar-qaada-cai`
+- **ckETH** (Chain-key Ethereum): `ss2fx-dyaaa-aaaar-qacoq-cai`
 
-``` bash
-docker pull dfinity/ic-icrc-rosetta-api
-```
+#### Test tokens (mainnet)
+- **TICRC1** (Test ICRC token): `3jkp5-oyaaa-aaaaj-azwqa-cai`
+- **ckTestBTC**: `mc6ru-gyaaa-aaaar-qaaaq-cai`
+- **ckTestETH**: `apia6-jaaaa-aaaar-qabma-cai`
 
-### Step 3: Start the integration software.
+## Supported operations
 
-#### From v2.1.0 - Multitoken tracking
-Run the following command:
-You can have a single ICRC Rosetta instance integrate with multiple tokens at the same time.
-You will need to know the canister IDs of the ICRC-1 ledgers you are trying to connect to. For example, to connect the ckBTC ICRC-1 ledger with the canister ID `mxzaz-hqaaa-aaaar-qaada-cai` and ckETH ICRC-1 (`ss2fx-dyaaa-aaaar-qacoq-cai`) which are running on the mainnet, the following call could be used:
-``` bash
-docker run \
-    --interactive \
-    --tty \
-    --publish 8082:8082 \
-    --rm \
-    dfinity/ic-icrc-rosetta-api \
-    --port 8082 \
-    --network-type mainnet \
-    --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai,ss2fx-dyaaa-aaaar-qacoq-cai \
-    --multi-tokens-store-dir /data
-```
+ICRC Rosetta supports various operations through its APIs:
 
-In this case, each token will use a separate SQLite database in the specified directory, named `/data/mxzaz-hqaaa-aaaar-qaada-cai.db` and `/data/ss2fx-dyaaa-aaaar-qacoq-cai.db` respectively.
+### Token operations
+- Account balance queries for multiple tokens
+- Transaction history retrieval across different ledgers
+- Transfer operations between accounts
+- Multi-token transaction construction and submission
 
-#### Before v2.1.0 - Single token tracking
-Run the following command:
-You will need to know the canister ID of the ICRC-1 ledger you are trying to connect to. For example, to connect the ckBTC ICRC-1 ledger with the canister ID `mxzaz-hqaaa-aaaar-qaada-cai` which is running on the mainnet, the following call could be used:
-``` bash
-docker run \
-    --interactive \
-    --tty \
-    --publish 8082:8082 \
-    --rm \
-    dfinity/ic-icrc-rosetta-api \
-    --port 8082 \
-    --network-type mainnet \
-    --ledger-id mxzaz-hqaaa-aaaar-qaada-cai \
-    --store-file /data/db.sqlite
+### Network operations
+- Network status and configuration queries
+- Token metadata retrieval (symbols, decimals, fees)
+- Block synchronization and monitoring
+- Real-time balance updates
 
-```
+### Supported endpoints
 
-#### Initialization logs
-In either case (Multi-token or legacy single token), the call specifies a port using `--port` which is used to publish through Docker.
-The default port, if not specified, is `8080`. The default network is the testnet.
-This command starts the software on the local host and displays output similar to the following:
+ICRC Rosetta implements the complete Rosetta specification including:
 
-```
-2025-04-04T11:15:25.840527Z  INFO rs/rosetta-api/icrc1/src/main.rs:447: ICRC Rosetta is connected to the ICRC-1 ledger: mxzaz-hqaaa-aaaar-qaada-cai
-2025-04-04T11:15:25.840649Z  INFO rs/rosetta-api/icrc1/src/main.rs:451: The token symbol of the ICRC-1 ledger is: ckBTC
-2025-04-04T11:15:30.467654Z  INFO rs/rosetta-api/icrc1/src/main.rs:447: ICRC Rosetta is connected to the ICRC-1 ledger: ss2fx-dyaaa-aaaar-qacoq-cai
-2025-04-04T11:15:30.467725Z  INFO rs/rosetta-api/icrc1/src/main.rs:451: The token symbol of the ICRC-1 ledger is: ckETH
-2025-04-04T11:15:30.468149Z  INFO rs/rosetta-api/icrc1/src/main.rs:603: Starting Rosetta server
-2025-04-04T11:15:30.468181Z  INFO rs/rosetta-api/icrc1/src/main.rs:604: Rosetta server is listening at: 0.0.0.0:8080
-2025-04-04T11:15:32.792226Z  INFO sync{token=ckETH-ss2fx}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:288: Fully synched to block height: 801941
-2025-04-04T11:15:37.490971Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:276: Progress: 99.01% (fetching 23356 of 2365800), ETA: 0.6min (607.4 blocks/s)
-2025-04-04T11:15:43.036138Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:276: Progress: 99.18% (fetching 19354 of 2365800), ETA: 0.5min (659.7 blocks/s)
-2025-04-04T11:15:48.416439Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:276: Progress: 99.44% (fetching 13351 of 2365800), ETA: 0.3min (799.8 blocks/s)
-2025-04-04T11:15:54.144698Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:276: Progress: 99.77% (fetching 5347 of 2365800), ETA: 0.1min (947.0 blocks/s)
-2025-04-04T11:16:00.456019Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:276: Progress: 100.00% (fetching 1 of 2365800), ETA: 0.0min (925.7 blocks/s)
-2025-04-04T11:16:00.456344Z  INFO sync{token=ckBTC-mxzaz}: rs/rosetta-api/icrc1/src/ledger_blocks_synchronization/blocks_synchronizer.rs:288: Fully synched to block height: 2365800
-```
+- **Data API**: For querying blockchain data and account information
+- **Construction API**: For creating and submitting transactions
+- **Network API**: For network information and status
 
-Notice that most logs are labeled with a `sync{token=...}` prefix, which indicates which of the tracked tokens is generating those logs.
+For detailed endpoint documentation, see the [Data API](./data_api/) and [Construction API](./construction_api/) sections.
 
+## Getting started
 
-For further help on what the options for ICRC Rosetta are, you can run the following command:
-``` bash
-docker run \
-    --interactive \
-    --tty \
-    --publish 8082:8082 \
-    --rm \
-    dfinity/ic-icrc-rosetta-api \
-    --help
-```
+To start using ICRC Rosetta, you'll need to set up a Rosetta node and configure it for the ICRC-1 ledgers you want to interact with. There are multiple deployment options available:
 
-By default, this software **does not** connect to any ICRC-1 ledger canister running on the Internet Computer blockchain mainnet.
+- **Docker deployment** (recommended for most users)
+- **Building from source** (for development and customization)
+- **Local cluster setup** (for testing with monitoring tools)
+- **Managed endpoints** (no local setup required)
 
-Currently, there is no ICRC-1 ledger running on the testnet. However, there are several test tokens running on mainnet such as ckTestBTC (`mc6ru-gyaaa-aaaar-qaaaq-cai`) and ckTestETH (`apia6-jaaaa-aaaar-qabma-cai`).
+### Test environment
 
-:::info
-The first time you run the command, it might take some time for the node to catch up to the current link of the chain.
-When the node is caught up, you should see output similar to the following:
+For testing and development, you can connect to the TICRC1 test token (`3jkp5-oyaaa-aaaaj-azwqa-cai`) that runs on mainnet but uses test tokens. Get free TICRC1 tokens from [Validation Cloud's faucet](https://docs.validationcloud.io/v1/about/faucets) to start experimenting with ICRC-1 functionality.
 
-```
-Synced Up to block height: 1357644
-```
+For detailed setup instructions, see the [Running Rosetta](./running-rosetta) guide.
 
-After that, ICRC Rosetta will update the account balances. Please wait for any queries that include fetching account balances until this process is done.
-The corresponding message you will see is:
+## Multi-token architecture
 
+ICRC Rosetta supports tracking multiple tokens simultaneously:
 
-```
-Account Balances have been updated successfully
-```
+### Database structure
+- Each token maintains a separate SQLite database
+- Database files are named after the canister ID (e.g., `mxzaz-hqaaa-aaaar-qaada-cai.db`)
+- Centralized logging with token-specific prefixes
 
-:::
-
-After completing this step, the node continues to run as a **passive** node that does not participate in block making.
-
-### Step 4:  Open a new terminal window or tab and run the `ps` command to verify the status of the service.
-
-If you need to stop the service, press <kbd>Ctrl-C</kbd>. You might want to do this to change the canister identifier you are using, for example.
-
-To test the integration after setting up the node, you will need to write a program to simulate a principal submitting a transaction or looking up an account balance.
-
-## Run the Rosetta node in production
-
-When you are finished testing, you should run the Docker image in production mode without the `--interactive`, `--tty`, and `--rm` command-line options.
-These command-line options are used to attach an interactive terminal session and remove the container and are primarily intended for testing purposes.
-To run the software in a production environment, you can start the Docker image using the `--detach` option to run the container in the background and, optionally, specify the `--volume` command for storing blocks.
-
-For more information about Docker command-line options, see the [Docker reference documentation](https://docs.docker.com/engine/reference/commandline/run/).
+### Network identification
+- Each token uses its canister ID as the network identifier
+- Rosetta calls must specify the target token's canister ID
+- Single node can serve multiple token networks
 
 ## Requirements and limitations
 
-The integration software provided in the Docker image has one requirement that is not part of the standard Rosetta API specification.
+The ICRC Rosetta implementation has specific requirements and limitations:
 
-For transactions involving ICRC-1 tokens, the unsigned transaction must be created less than 24 hours before the network receives the signed transaction.
-The reason for this is the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication).
-Any submitted transaction that refers back to a too old transaction is rejected to maintain operational efficiency.
+### Transaction timing requirement
 
-Other than this requirement, the Rosetta API integration software fully complies with all standard Rosetta endpoints and passes all of the `rosetta-cli` tests.
-The software can accept any valid Rosetta request.
-However, the integration software only prompts for transactions to be signed using Ed25519 and SECP256k1, rather than all the [signature schemes listed](https://www.rosetta-api.org/docs/models/SignatureType.html#values), and only replies with a small subset of the potential responses that the specification supports.
-For example, the software doesn’t implement any of the UTXO features of Rosetta, so you won’t see any UTXO messages in any of the software responses.
+For transactions involving ICRC-1 tokens, the unsigned transaction must be created less than 24 hours before the network receives the signed transaction. This is due to the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication). Any submitted transaction that refers back to a transaction older than 24 hours is rejected to maintain operational efficiency.
+
+### Signature schemes
+
+The examples and documentation typically use:
+- **Ed25519**
+- **SECP256k1**
+
+For the complete list of supported signature schemes, refer to the [Rosetta specification](https://www.rosetta-api.org/docs/models/SignatureType.html#values).
+
+### Response format
+
+The integration software only replies with a subset of the potential responses that the specification supports. For example:
+- No UTXO features are implemented
+- No UTXO messages appear in any software responses
+
+### Network limitations
+
+- **Network support**: All production and test tokens run on mainnet
+- **Test ledgers**: Test tokens are available as separate ledgers on mainnet
+- **Default port**: 8082 (different from ICP Rosetta's 8081)
+
+### Compliance
+
+Other than the 24-hour transaction timing requirement, the ICRC Rosetta API integration software:
+- ✅ Fully complies with all standard Rosetta endpoints
+- ✅ Passes all `rosetta-cli` tests
+- ✅ Accepts any valid Rosetta request
 
 ## Frequently asked questions
-The following questions come from the most commonly reported questions and blockers from the developer community regarding Rosetta integration with the Internet Computer.
 
-#### How do I connect the Rosetta node to the mainnet?
-Use flags `--network-type mainnet`
+### How do I run an instance of ICRC Rosetta?
 
-#### How do I know if the node has caught up with the testnet?
-Search the `Starting Rosetta API server` startup log. There will be a log entry that says `Synced Up to block height: XX`.
-This message confirms that you are caught up with all blocks.
+The easiest way is to use the [`dfinity/ic-icrc-rosetta-api`](https://hub.docker.com/r/dfinity/ic-icrc-rosetta-api/tags) Docker image. See the [Running Rosetta](./running-rosetta) guide for detailed instructions on all deployment methods.
 
-#### How to persist synced blocks data?
-Mount the `/data` directory as a [volume](https://docs.docker.com/storage/volumes/).
+### How do I connect to multiple tokens?
+
+Use the `--multi-tokens` flag with comma-separated canister IDs:
+
+```bash
+--multi-tokens mxzaz-hqaaa-aaaar-qaada-cai,ss2fx-dyaaa-aaaar-qacoq-cai
+```
+
+### How do I connect to mainnet?
+
+Use the flag `--network-type mainnet` when starting your ICRC Rosetta node.
+
+### How do I know if the node has caught up?
+
+Look for these log entries for each token:
+```
+Synced Up to block height: XXXXX
+Account Balances have been updated successfully
+```
+
+### How do I persist synced block data?
+
+Mount the `/data` directory as a Docker volume:
 
 ```bash
 docker volume create ic-icrc-rosetta
+docker run \
+    --volume ic-icrc-rosetta:/data \
+    --publish 8082:8082 \
+    --detach \
+    dfinity/ic-icrc-rosetta-api \
+    --multi-tokens-store-dir /data
 ```
+
+### Is ICRC Rosetta versioned?
+
+Yes, new versions are regularly published on [DockerHub](https://hub.docker.com/r/dfinity/ic-icrc-rosetta-api/tags). It's recommended to use specific versions in production (e.g., `dfinity/ic-icrc-rosetta-api:v2.1.0`).
+
+You can query the version using the `/network/options` endpoint:
 
 ```bash
-docker run \
-    --volume ic-icrc-rosetta:/data \
-    --interactive \
-    --tty \
-    --publish 8082:8082 \
-    --rm \
-   dfinity/ic-icrc-rosetta-api \
-    --network-type mainnet \
-    --port 8082 \
-    --ledger-id mxzaz-hqaaa-aaaar-qaada-cai \
-    --store-file /data/db.sqlite
-
+curl -H 'Content-Type: application/json' \
+  -d '{
+    "network_identifier": {
+      "blockchain": "Internet Computer",
+      "network": "mxzaz-hqaaa-aaaar-qaada-cai"
+    }
+  }' \
+  -X POST http://localhost:8082/network/options | jq '.version.node_version'
 ```
 
-#### Is the Rosetta node versioned?
+### What's the default port?
 
-Yes, new versions are regularly published on [DockerHub](https://hub.docker.com/r/dfinity/ic-icrc-rosetta-api/tags).
-It is recommended to use a specific version in production settings, e.g., `dfinity/ic-icrc-rosetta-api:v1.0.0`
-You can query the version of a running Rosetta node using the `/network/options` endpoint.
+ICRC Rosetta listens on port **8082** by default (different from ICP Rosetta which uses 8081).
 
-```console
-$ curl -s -q -H 'Content-Type: application/json' -d '{
-    "network_identifier": {
-            "blockchain": "Internet Computer",
-            "network": "mxzaz-hqaaa-aaaar-qaada-cai"
-    },
-    "metadata": {}
-}' --location '0.0.0.0:8082/network/options' | jq '.version.node_version'
+### Can I track custom ICRC-1 tokens?
 
-"1.0.0"
-```
+Yes, ICRC Rosetta can connect to any ICRC-1 compatible ledger. Simply provide the canister ID of your custom token when starting the node.
+
+### How do I get test tokens for development?
+
+Use [Validation Cloud's free faucet](https://docs.validationcloud.io/v1/about/faucets) to get:
+- **TICRC1** tokens for testing ICRC-1 functionality
+- **TESTICP** tokens for testing ICP Rosetta
+
+These test tokens run on mainnet but are separate from production tokens, making them perfect for development and testing.

--- a/docs/defi/rosetta/icrc_rosetta/running-rosetta.mdx
+++ b/docs/defi/rosetta/icrc_rosetta/running-rosetta.mdx
@@ -1,0 +1,339 @@
+---
+keywords: [intermediate, rosetta, tutorial, docker, source, icrc, ledger, deployment]
+---
+
+import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
+
+# Running ICRC Rosetta
+
+<MarkdownChipRow labels={["Intermediate", "Rosetta"]} />
+
+There are several ways to run ICRC Rosetta depending on your use case and requirements. This guide covers all available deployment methods for connecting to ICRC-1 compatible ledgers like ckBTC and ckETH.
+
+## Docker (Recommended)
+
+The easiest way to run ICRC Rosetta is using the official Docker image. This method is recommended for most users.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- [Docker daemon](https://docs.docker.com/config/daemon/) started
+- ICRC-1 ledger canister IDs you want to connect to
+
+### Step 1: Pull the latest image
+
+```bash
+docker pull dfinity/ic-icrc-rosetta-api
+```
+
+### Step 2: Run the container
+
+#### Multi-token tracking (v2.1.0+)
+
+Connect to multiple ICRC-1 ledgers simultaneously:
+
+```bash
+docker run \
+    --interactive \
+    --tty \
+    --publish 8082:8082 \
+    --rm \
+    dfinity/ic-icrc-rosetta-api \
+    --port 8082 \
+    --network-type mainnet \
+    --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai,ss2fx-dyaaa-aaaar-qacoq-cai \
+    --multi-tokens-store-dir /data
+```
+
+This example connects to both ckBTC (`mxzaz-hqaaa-aaaar-qaada-cai`) and ckETH (`ss2fx-dyaaa-aaaar-qacoq-cai`) ledgers.
+
+#### Single token tracking (legacy)
+
+Connect to a single ICRC-1 ledger:
+
+```bash
+docker run \
+    --interactive \
+    --tty \
+    --publish 8082:8082 \
+    --rm \
+    dfinity/ic-icrc-rosetta-api \
+    --port 8082 \
+    --network-type mainnet \
+    --ledger-id mxzaz-hqaaa-aaaar-qaada-cai \
+    --store-file /data/db.sqlite
+```
+
+### Step 3: Production deployment
+
+For production environments, run without interactive flags and persist data:
+
+```bash
+# Create a volume for data persistence
+docker volume create ic-icrc-rosetta
+
+# Run in production mode with multi-token support
+docker run \
+    --volume ic-icrc-rosetta:/data \
+    --publish 8082:8082 \
+    --detach \
+    dfinity/ic-icrc-rosetta-api \
+    --port 8082 \
+    --network-type mainnet \
+    --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai,ss2fx-dyaaa-aaaar-qacoq-cai \
+    --multi-tokens-store-dir /data
+```
+
+### Common ledger canister IDs
+
+#### Mainnet tokens
+- **ckBTC**: `mxzaz-hqaaa-aaaar-qaada-cai`
+- **ckETH**: `ss2fx-dyaaa-aaaar-qacoq-cai`
+
+#### Test tokens (on mainnet)
+- **TICRC1** (Test ICRC token): `3jkp5-oyaaa-aaaaj-azwqa-cai`
+- **ckTestBTC**: `mc6ru-gyaaa-aaaar-qaaaq-cai`
+- **ckTestETH**: `apia6-jaaaa-aaaar-qabma-cai`
+
+:::tip
+Get free TICRC1 test tokens from [Validation Cloud's faucet](https://docs.validationcloud.io/v1/about/faucets) to start testing ICRC Rosetta without using real tokens.
+:::
+
+### Docker versioning
+
+It's recommended to use specific versions in production:
+
+```bash
+docker run \
+    --publish 8082:8082 \
+    --detach \
+    dfinity/ic-icrc-rosetta-api:v2.1.0 \
+    --port 8082 \
+    --network-type mainnet \
+    --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai
+```
+
+Check available versions on [DockerHub](https://hub.docker.com/r/dfinity/ic-icrc-rosetta-api/tags).
+
+### Getting help
+
+View all available options:
+
+```bash
+docker run \
+    --rm \
+    dfinity/ic-icrc-rosetta-api \
+    --help
+```
+
+## From Source
+
+You can build and run ICRC Rosetta directly from the Internet Computer source code.
+
+### Prerequisites
+
+- [Bazel](https://bazel.build/) build system
+- Internet Computer repository cloned locally
+
+### Building and running
+
+```bash
+# Clone the IC repository (if not already done)
+git clone https://github.com/dfinity/ic.git
+cd ic
+
+# Build and run ICRC Rosetta
+bazel run //rs/rosetta-api/icrc1:ic-icrc-rosetta-api -- \
+    --port 8082 \
+    --network-type mainnet \
+    --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai \
+    --multi-tokens-store-dir /tmp/icrc-rosetta-data
+```
+
+This method gives you the latest development version and allows for custom modifications.
+
+## Local Cluster
+
+For development and testing purposes, you can set up a complete local Kubernetes cluster with monitoring tools that includes ICRC Rosetta.
+
+### Overview
+
+The local cluster setup provides:
+- Minikube-based Kubernetes cluster
+- Prometheus and Grafana for monitoring
+- cAdvisor for container metrics
+- Both ICP and ICRC1 Rosetta services
+
+### Prerequisites
+
+The deployment script will help install missing dependencies:
+- Docker
+- Minikube
+- kubectl
+- Helm
+
+### Deploying production images
+
+```bash
+# Clone the IC repository
+git clone https://github.com/dfinity/ic.git
+cd ic/rs/rosetta-api/local/cluster
+
+# Deploy with default configuration
+./deploy.sh
+
+# Deploy with specific ICRC1 ledger
+./deploy.sh --icrc1-ledger mxzaz-hqaaa-aaaar-qaada-cai
+```
+
+### Deploying local images
+
+First, build the containers from within the dev container:
+
+```bash
+# Enter dev container
+./ci/container/container-run.sh
+
+# Build ICRC1 Rosetta
+bazel build //rs/rosetta-api/icrc1:icrc_rosetta_image.tar
+mv bazel-bin/rs/rosetta-api/icrc1/icrc_rosetta_image.tar /tmp
+
+# Exit dev container
+exit
+```
+
+Then deploy the local images:
+
+```bash
+./deploy.sh --local-icrc1-image-tar /tmp/icrc_rosetta_image.tar
+```
+
+### Monitoring with Grafana
+
+Access Grafana at `http://localhost:3000` with:
+- Username: `admin`
+- Password: `admin`
+
+Import the dashboard using the `rosetta_load_dashboard.json` file in the cluster directory.
+
+## Validation Cloud
+
+For those who prefer not to run Rosetta locally, Validation Cloud offers managed ICRC Rosetta endpoints that you can use for learning, development, and production.
+
+### Features
+
+- Managed infrastructure (no local setup required)
+- Global distribution with multi-region support
+- 99.99% uptime SLA
+- 24/7 customer support
+- SOC 2 Type 2 compliance
+
+### Getting started
+
+1. Visit [Validation Cloud ICP page](https://www.validationcloud.io/icp)
+2. Sign up for an account
+3. Choose between Free tier (50M Compute Units) or Scale plan (unlimited)
+4. Get your API endpoint and start building
+
+### Supported APIs
+
+- ICRC API for token interactions
+- Access to chain-key token ledgers (ckBTC, ckETH)
+- Multi-token support
+
+This option is useful for:
+- Quick prototyping and learning
+- Development without local infrastructure setup
+- Production applications that prefer managed services
+
+## Verification and testing
+
+Regardless of the deployment method, you can verify your ICRC Rosetta node is working:
+
+### Check node status
+
+```bash
+curl -H "Content-Type: application/json" \
+  -d '{
+    "network_identifier": {
+      "blockchain": "Internet Computer",
+      "network": "mxzaz-hqaaa-aaaar-qaada-cai"
+    }
+  }' \
+  -X POST http://localhost:8082/network/status
+```
+
+### Check version
+
+```bash
+curl -H "Content-Type: application/json" \
+  -d '{
+    "network_identifier": {
+      "blockchain": "Internet Computer", 
+      "network": "mxzaz-hqaaa-aaaar-qaada-cai"
+    }
+  }' \
+  -X POST http://localhost:8082/network/options | jq '.version.node_version'
+```
+
+### Wait for sync
+
+Look for these messages in the logs to confirm synchronization:
+
+```
+Synced Up to block height: XXXXX
+Account Balances have been updated successfully
+```
+
+## Understanding the logs
+
+ICRC Rosetta logs include token-specific prefixes for multi-token deployments:
+
+```
+INFO sync{token=ckBTC-mxzaz}: Fully synched to block height: 2365800
+INFO sync{token=ckETH-ss2fx}: Fully synched to block height: 801941
+```
+
+The `sync{token=...}` prefix indicates which tracked token is generating the logs.
+
+## Requirements and limitations
+
+- **Transaction timing**: Unsigned transactions must be created less than 24 hours before submission due to the [deduplication mechanism](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication)
+- **Signature schemes**: Examples typically use Ed25519 and SECP256k1
+- **Default port**: 8082 (vs 8081 for ICP Rosetta)
+- **Network support**: Mainnet (test ledgers are also available on mainnet)
+- **Data persistence**: Mount `/data` directory as a volume for Docker deployments
+- **Database files**: Each token uses a separate SQLite database when using multi-token mode
+
+## Common configuration examples
+
+### ckBTC only
+```bash
+docker run -p 8082:8082 --detach \
+  dfinity/ic-icrc-rosetta-api \
+  --network-type mainnet \
+  --ledger-id mxzaz-hqaaa-aaaar-qaada-cai
+```
+
+### ckBTC + ckETH
+```bash
+docker run -p 8082:8082 --detach \
+  dfinity/ic-icrc-rosetta-api \
+  --network-type mainnet \
+  --multi-tokens mxzaz-hqaaa-aaaar-qaada-cai,ss2fx-dyaaa-aaaar-qacoq-cai
+```
+
+### Test tokens for development
+```bash
+# TICRC1 test token only
+docker run -p 8082:8082 --detach \
+  dfinity/ic-icrc-rosetta-api \
+  --network-type mainnet \
+  --ledger-id 3jkp5-oyaaa-aaaaj-azwqa-cai
+
+# Multiple test tokens
+docker run -p 8082:8082 --detach \
+  dfinity/ic-icrc-rosetta-api \
+  --network-type mainnet \
+  --multi-tokens 3jkp5-oyaaa-aaaaj-azwqa-cai,mc6ru-gyaaa-aaaar-qaaaq-cai,apia6-jaaaa-aaaar-qabma-cai
+``` 

--- a/roadmap/roadmap.json
+++ b/roadmap/roadmap.json
@@ -1300,18 +1300,6 @@
             "in_beta": false
           },
           {
-            "title": "Native USDC integration through CCTP",
-            "overview": "Bringing USD Coin (USDC) natively to ICP via integration with Circle's CCTP (Cross-Chain Transfer Protocol).",
-            "forum": "",
-            "proposal": "",
-            "docs": "",
-            "eta": "",
-            "status": "future",
-            "is_community": true,
-            "in_beta": false,
-            "milestone_id": ""
-          },
-          {
             "title": "BTC ordinals indexer and inscriber",
             "overview": "BTC ordinals indexer and inscriber running fully on chain on ICP. Adding a missing decentralized piece of infrastructure to the Bitcoin ecosystem to help it become more decentralized.",
             "status": "",
@@ -1496,7 +1484,7 @@
         "name": "Decentralized access logs and metrics",
         "milestone_id": "Levitron",
         "description": "This milestone enhances visibility into the Internet Computer's edge infrastructure by making aggregated API boundary node access logs publicly accessible. Developers gain valuable insights into their dapps' usage patterns, enabling traffic analysis and user statistics. To ensure log integrity and verifiability, this milestone builds on the trusted execution environments introduced in Magnetosphere.",
-        "eta": "June 2025",
+        "eta": "July 2025",
         "status": "in_progress",
         "elements": [
           {
@@ -1534,7 +1522,7 @@
           {
             "title": "Generation 3 node hardware",
             "overview": "Define the hardware specifications for the next generation of nodes, supporting the future growth of the network. ",
-            "status": "future",
+            "status": "in_progress",
             "milestone_id": "Knot"
           },
           {

--- a/sidebars.js
+++ b/sidebars.js
@@ -676,34 +676,35 @@ defi: [
         label: "DeFi on ICP",
         id: "defi/overview",
       },
-      {
-        type: "category",
-        label: "ICP Rosetta implementation",
-        link: {
-          type: "doc",
-          id: "defi/rosetta/icp_rosetta/index",
-        },
-        items: [
-          {
+              {
+          type: "category",
+          label: "ICP Rosetta implementation",
+          link: {
             type: "doc",
-            label: "Data API",
-            id: "defi/rosetta/icp_rosetta/data_api/index",
-            },
-          {
-            type: "category",
-            label: "Construction API",
-            link: {
+            id: "defi/rosetta/icp_rosetta/index",
+          },
+          items: [
+            "defi/rosetta/icp_rosetta/running-rosetta",
+            {
               type: "doc",
-              id: "defi/rosetta/icp_rosetta/construction_api/index",
-            },
-            items: [
-            "defi/rosetta/icp_rosetta/construction_api/operations-flow",
-            "defi/rosetta/icp_rosetta/construction_api/staking",
-            "defi/rosetta/icp_rosetta/construction_api/voting",
+              label: "Data API",
+              id: "defi/rosetta/icp_rosetta/data_api/index",
+              },
+            {
+              type: "category",
+              label: "Construction API",
+              link: {
+                type: "doc",
+                id: "defi/rosetta/icp_rosetta/construction_api/index",
+              },
+              items: [
+              "defi/rosetta/icp_rosetta/construction_api/operations-flow",
+              "defi/rosetta/icp_rosetta/construction_api/staking",
+              "defi/rosetta/icp_rosetta/construction_api/voting",
+              ],
+              },
             ],
-            },
-          ],
-        },
+          },
         {
           type: "category",
           label: "ICRC Rosetta implementation",
@@ -712,6 +713,7 @@ defi: [
             id: "defi/rosetta/icrc_rosetta/index",
           },
           items: [
+            "defi/rosetta/icrc_rosetta/running-rosetta",
             {
               type: "doc",
               label: "Data API",


### PR DESCRIPTION
This guide version updates the existing ways of running Rosetta, including Validation Cloud and the local kubernetes cluster.