### PR TITLE
add: Motoko code to vetKeys encrypted maps

### DIFF
--- a/docs/building-apps/network-features/vetkeys/dkms.mdx
+++ b/docs/building-apps/network-features/vetkeys/dkms.mdx
@@ -68,16 +68,6 @@ For an example implementation, see [`DefaultKeyManagerClient`](https://github.co
 
 <AdornedTabs groupId="languages">
 
-<TabItem value="rs" label="Rust" default>
-
-Below is an example of how to instantiate the backend `KeyManager` component inside a canister.
-
-```rust no-repl reference
-https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs#L1-L36
-```
-
-</TabItem>
-
 <TabItem value="motoko" label="Motoko">
 
 Below is an example of how to instantiate the backend `KeyManager` component inside a canister.
@@ -87,21 +77,21 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 ```
 
 </TabItem>
+
+<TabItem value="rs" label="Rust">
+
+Below is an example of how to instantiate the backend `KeyManager` component inside a canister.
+
+```rust reference
+https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs#L1-L36
+```
+
+</TabItem>
 </AdornedTabs>
 
 ### Step 2: Define backend canister APIs for the frontend to communicate with
 
 <AdornedTabs groupId="languages">
-
-<TabItem value="rs" label="Rust" default>
-
-Below is an example of how to create a backend canister API that allows the frontend to interact with the `get_encrypted_vetkey` method of the `KeyManager` component. You can follow a similar pattern to expose additional methods of the `KeyManager` through canister APIs.
-
-```rust no-repl reference
-https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs#L71-L88
-```
-
-</TabItem>
 
 <TabItem value="motoko" label="Motoko">
 
@@ -112,17 +102,27 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 ```
 
 </TabItem>
+
+<TabItem value="rs" label="Rust">
+
+Below is an example of how to create a backend canister API that allows the frontend to interact with the `get_encrypted_vetkey` method of the `KeyManager` component. You can follow a similar pattern to expose additional methods of the `KeyManager` through canister APIs.
+
+```rust reference
+https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs#L71-L88
+```
+
+</TabItem>
 </AdornedTabs>
 
 ### Step 3: Implement `KeyManagerClient` in the frontend
 
 <AdornedTabs groupId="languages">
 
-<TabItem value="ts" label="Typescript" default>
+<TabItem value="ts" label="Typescript">
 
 Below is an example of how to provide a `KeyManagerClient` implementation to interact with the backend `KeyManager` component’s method for obtaining an encrypted vetKey. Implementations for other methods of `KeyManager` can be added in a similar fashion.
 
-```ts no-repl reference
+```ts reference
 https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/frontend/ic_vetkeys/src/key_manager/key_manager_canister.ts#L50-L60
 ```
 
@@ -134,7 +134,7 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 Your application's frontend can communicate with a backend canister that exposes `KeyManager` API methods using the following TypeScript code:
 
 <AdornedTabs groupId="languages">
-<TabItem value="ts" label="Typescript" default>
+<TabItem value="ts" label="Typescript">
 
 ```ts
 import { KeyManager } from "ic_vetkeys/key_manager";

--- a/docs/building-apps/network-features/vetkeys/encrypted-onchain-storage.mdx
+++ b/docs/building-apps/network-features/vetkeys/encrypted-onchain-storage.mdx
@@ -61,12 +61,21 @@ Beyond the inherited features of `KeyManager`, `EncryptedMaps` has also the foll
 ### Step 1: Instantiate the `EncryptedMaps` component in a backend canister
 
 <AdornedTabs groupId="languages">
-<TabItem value="rs" label="Rust" default>
+<TabItem value="mo" label="Motoko">
 
 Below is an example of how to instantiate the `EncryptedMaps` component inside a backend canister.
 
-```rust no-repl reference
-https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs#L1-L38
+```motoko no-repl reference
+https://github.com/dfinity/vetkeys/blob/dc40657e8e894f5b9a095fcc3cc5e8f9fe5e8405/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo#L1-L10
+```
+</TabItem>
+
+<TabItem value="rs" label="Rust">
+
+Below is an example of how to instantiate the `EncryptedMaps` component inside a backend canister.
+
+```rust reference
+https://github.com/dfinity/vetkeys/blob/dc40657e8e894f5b9a095fcc3cc5e8f9fe5e8405/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs#L1-L38
 ```
 
 </TabItem>
@@ -75,14 +84,25 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 ### Step 2: Define `EncryptedMaps` canister APIs for the frontend to communicate with
 
 <AdornedTabs groupId="languages">
-<TabItem value="rs" label="Rust" default>
+<TabItem value="mo" label="Motoko">
 
-Below is an example of how to implement a backend canister API that allows the frontend to interact with the `set_user_rights` method of the `EncryptedMaps` component.
+Below is an example of how to implement a backend canister API that allows the frontend to interact with the `getEncryptedValue` method of the `EncryptedMaps` component.
 
 You can follow a similar approach to expose other methods of `EncryptedMaps` through the canister interface.
 
-```rust no-repl reference
-https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs#L255-L272
+```motoko no-repl reference
+https://github.com/dfinity/vetkeys/blob/dc40657e8e894f5b9a095fcc3cc5e8f9fe5e8405/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo#L101-L112
+```
+</TabItem>
+
+<TabItem value="rs" label="Rust">
+
+Below is an example of how to implement a backend canister API that allows the frontend to interact with the `get_encrypted_value` method of the `EncryptedMaps` component.
+
+You can follow a similar approach to expose other methods of `EncryptedMaps` through the canister interface.
+
+```rust reference
+https://github.com/dfinity/vetkeys/blob/dc40657e8e894f5b9a095fcc3cc5e8f9fe5e8405/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs#L121-L136
 ```
 
 </TabItem>
@@ -92,14 +112,14 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 
 <AdornedTabs groupId="languages">
 
-<TabItem value="ts" label="Typescript" default>
+<TabItem value="ts" label="Typescript">
 
-Below is an example of how to implement a backend canister API that allows the frontend to interact with the `set_user_rights` method of the `EncryptedMaps` component.
+Below is an example of how to implement a backend canister API that allows the frontend to interact with the `get_encrypted_value` method of the `EncryptedMaps` component.
 
 You can follow a similar approach to expose other methods of `EncryptedMaps` through the canister interface.
 
-```ts no-repl reference
-https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts#L100-L107
+```ts reference
+https://github.com/dfinity/vetkeys/blob/dc40657e8e894f5b9a095fcc3cc5e8f9fe5e8405/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts#L44-L50
 ```
 
 </TabItem>
@@ -110,7 +130,7 @@ https://github.com/dfinity/vetkeys/blob/dd255c8fa1ec0356f9448f1728ed4d6a5b736308
 Your application's frontend can communicate with a backend canister that exposes `EncryptedMaps` API methods using the following TypeScript code:
 
 <AdornedTabs groupId="languages">
-<TabItem value="ts" label="Typescript" default>
+<TabItem value="ts" label="Typescript">
 
 
 ```ts


### PR DESCRIPTION
Also changes which method of encrypted maps we showcase (`set_user_rights` -> `get_encrypted_value`) and makes minor adjustments on the DKMS page.