### PR TITLE
fix: `includes` tag in Motoko code blocks

### DIFF
--- a/src/theme/CodeBlock/Content/String.js
+++ b/src/theme/CodeBlock/Content/String.js
@@ -63,7 +63,7 @@ export default function StringWrapper(props) {
             />
           </div>
         )}
-        <String {...props} />
+        <div id={props.name}><String {...props} /></div>
       </Container>
       {(output || error) && showRunButton ? (
         <Container as="div">


### PR DESCRIPTION
Fixes a regression involving a theme change which broke Motoko code snippets which reference another on the same page. 