### PR TITLE
Redirect `/docs/motoko` to `/docs/motoko/home`

### DIFF
--- a/plugins/utils/redirects.js
+++ b/plugins/utils/redirects.js
@@ -163,6 +163,7 @@ const redirects = `
 
   # Motoko old -> new docs
 
+  /docs/motoko /docs/motoko/home
   /docs/motoko/main/base/ /docs/motoko/base/
   /docs/current/motoko/main/base/ /docs/motoko/base/
   /docs/motoko/main/base/Array /docs/motoko/base/Array


### PR DESCRIPTION
Currently, https://internetcomputer.org/docs/motoko is a 404 page which seems reasonable to redirect to https://internetcomputer.org/docs/motoko/home.