### PR TITLE
crypto: CRP-2886 extend changelog

### DIFF
--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,8 @@
 ## Changelog {#changelog}
 
+### 0.43.0 (2025-07-17) {$0_43_0}
+* VetKD API is considered stable.
+
 ### 0.42.0 (2025-06-06) {#0_42_0}
 * New system API `ic0.root_key_{size, copy}` for fetching the public key of the IC root key.
 


### PR DESCRIPTION
Adds a changelog entry for the changes in https://github.com/dfinity/portal/pull/5943.