### PR TITLE
use hcaptcha for kapa as per recommendation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -604,6 +604,7 @@ const config = {
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
       "data-website-id": "08910249-851f-465b-b60f-238d84e1afc1",
+      "data-bot-protection-mechanism": "hcaptcha",
       "data-project-name": "Internet Computer",
       "data-project-color": "#172234",
       "data-project-logo":


### PR DESCRIPTION
- as discussed on Slack, bot detection of bot traffic works better with hCaptcha than reCaptcha which is the default