### PR TITLE
docs(rosetta): remove local cluster deployment option

### DIFF
--- a/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
+++ b/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
@@ -95,7 +95,7 @@ You can build and run ICP Rosetta directly from the Internet Computer source cod
 
 ### Prerequisites
 
-- [x] [Rust](https://www.rust-lang.org/) Rust
+- [x] [Bazel](https://bazel.build/) build system.
 - [x] Internet Computer repository cloned locally: `git clone https://github.com/dfinity/ic.git`.
 
 ### Build and run
@@ -106,7 +106,7 @@ git clone https://github.com/dfinity/ic.git
 cd ic
 
 # Build and run ICP Rosetta
-cargo run --release --package ic-rosetta-api -- \
+bazel run //rs/rosetta-api/icp:ic-rosetta-api -- \
     --port 8081 \
     --environment production \
     --store-location /tmp

--- a/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
+++ b/docs/defi/rosetta/icp_rosetta/running-rosetta.mdx
@@ -1,5 +1,5 @@
 ---
-keywords: [intermediate, rosetta, tutorial, docker, source, local cluster, validation cloud, deployment]
+keywords: [intermediate, rosetta, tutorial, docker, source, validation cloud, deployment]
 ---
 
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
@@ -95,7 +95,7 @@ You can build and run ICP Rosetta directly from the Internet Computer source cod
 
 ### Prerequisites
 
-- [x] [Bazel](https://bazel.build/) build system.
+- [x] [Rust](https://www.rust-lang.org/) Rust
 - [x] Internet Computer repository cloned locally: `git clone https://github.com/dfinity/ic.git`.
 
 ### Build and run
@@ -106,7 +106,7 @@ git clone https://github.com/dfinity/ic.git
 cd ic
 
 # Build and run ICP Rosetta
-bazel run //rs/rosetta-api/icp:ic-rosetta-api -- \
+cargo run --release --package ic-rosetta-api -- \
     --port 8081 \
     --environment production \
     --store-location /tmp
@@ -117,84 +117,6 @@ The `--store-location` parameter is important when running from source as it spe
 :::
 
 This method gives you the latest development version and allows for custom modifications.
-
-## Local cluster
-
-For development and testing purposes, you can set up a complete local Kubernetes cluster with monitoring tools.
-
-
-The local cluster setup provides:
-- Minikube-based Kubernetes cluster.
-- Prometheus and Grafana for monitoring.
-- cAdvisor for container metrics.
-- Both ICP and ICRC1 Rosetta services.
-
-The deployment script will help install missing dependencies:
-- Docker.
-- Minikube.
-- kubectl.
-- Helm.
-
-### Deploying production images
-
-```bash
-# Clone the IC repository
-git clone https://github.com/dfinity/ic.git
-cd ic/rs/rosetta-api/local/cluster
-
-# Deploy with default test ledgers
-./deploy.sh
-
-# Deploy pointing to specific ledgers
-./deploy.sh \
-    --icp-ledger xafvr-biaaa-aaaai-aql5q-cai \
-    --icp-symbol TESTICP \
-    --icrc1-ledger 3jkp5-oyaaa-aaaaj-azwqa-cai
-```
-
-### Deploying local images
-
-First, build the containers from within the dev container:
-
-```bash
-# Enter dev container
-./ci/container/container-run.sh
-
-# Build ICP Rosetta
-bazel build //rs/rosetta-api/icp:rosetta_image.tar
-mv bazel-bin/rs/rosetta-api/icp/rosetta_image.tar /tmp
-
-# Build ICRC1 Rosetta
-bazel build //rs/rosetta-api/icrc1:icrc_rosetta_image.tar
-mv bazel-bin/rs/rosetta-api/icrc1/icrc_rosetta_image.tar /tmp
-
-# Exit dev container
-exit
-```
-
-Then deploy the local images:
-
-```bash
-./deploy.sh \
-    --local-icp-image-tar /tmp/rosetta_image.tar \
-    --local-icrc1-image-tar /tmp/icrc_rosetta_image.tar
-```
-
-### Monitoring with Grafana
-
-Access Grafana at `http://localhost:3000` with:
-- Username: `admin`.
-- Password: `admin`.
-
-Import the dashboard using the `rosetta_load_dashboard.json` file in the cluster directory.
-
-### Cleaning up
-
-To start fresh:
-
-```bash
-./deploy.sh --clean
-```
 
 ## Validation Cloud
 

--- a/docs/defi/rosetta/icrc_rosetta/running-rosetta.mdx
+++ b/docs/defi/rosetta/icrc_rosetta/running-rosetta.mdx
@@ -131,69 +131,6 @@ bazel run //rs/rosetta-api/icrc1:ic-icrc-rosetta-bin -- \
 
 This method gives you the latest development version and allows for custom modifications.
 
-## Local cluster
-
-For development and testing purposes, you can set up a complete local Kubernetes cluster with monitoring tools that includes ICRC Rosetta.
-
-
-The local cluster setup provides:
-- Minikube-based Kubernetes cluster.
-- Prometheus and Grafana for monitoring.
-- cAdvisor for container metrics.
-- Both ICP and ICRC1 Rosetta services.
-
-### Prerequisites
-
-The deployment script will help install missing dependencies:
-- Docker.
-- Minikube.
-- kubectl.
-- Helm.
-
-### Deploying production images
-
-```bash
-# Clone the IC repository
-git clone https://github.com/dfinity/ic.git
-cd ic/rs/rosetta-api/local/cluster
-
-# Deploy with default configuration
-./deploy.sh
-
-# Deploy with specific ICRC1 ledger
-./deploy.sh --icrc1-ledger mxzaz-hqaaa-aaaar-qaada-cai
-```
-
-### Deploying local images
-
-First, build the containers from within the dev container:
-
-```bash
-# Enter dev container
-./ci/container/container-run.sh
-
-# Build ICRC1 Rosetta
-bazel build //rs/rosetta-api/icrc1:icrc_rosetta_image.tar
-mv bazel-bin/rs/rosetta-api/icrc1/icrc_rosetta_image.tar /tmp
-
-# Exit dev container
-exit
-```
-
-Then deploy the local images:
-
-```bash
-./deploy.sh --local-icrc1-image-tar /tmp/icrc_rosetta_image.tar
-```
-
-### Monitoring with Grafana
-
-Access Grafana at `http://localhost:3000` with:
-- Username: `admin`.
-- Password: `admin`.
-
-Import the dashboard using the `rosetta_load_dashboard.json` file in the cluster directory.
-
 ## Validation Cloud
 
 For those who prefer not to run Rosetta locally, Validation Cloud offers managed ICRC Rosetta endpoints that you can use for learning, development, and production.


### PR DESCRIPTION
The local cluster option is practically unmaintained at the moment, with unclear benefits compared to alternative deployment options like docker and validation cloud. This commit removes the local cluster deployment options from the docs. We can introduce it later when/if there's a need for it.