### PR TITLE
Fix link to security best practices in documentation

### DIFF
--- a/docs/references/message-execution-properties.mdx
+++ b/docs/references/message-execution-properties.mdx
@@ -6,7 +6,7 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 ## Asynchronous messaging model
 
-ICP relies on an asynchronous messaging model. Compared to synchronous messaging like on Ethereum, this provides performance advantages because multiple calls can be executed concurrently — and also in parallel, when multiple canisters are involved. However, asynchronous message execution can also lead to sometimes unexpected or unintuitive behavior. Therefore, it is important to understand the properties of message execution. Potential security issues that arise in this model, such as reentrancy bugs, are discussed in the [security best practices on inter-canister calls](/docs/current/developer-docs/security/security-best-practices/inter-canister-calls).
+ICP relies on an asynchronous messaging model. Compared to synchronous messaging like on Ethereum, this provides performance advantages because multiple calls can be executed concurrently — and also in parallel, when multiple canisters are involved. However, asynchronous message execution can also lead to sometimes unexpected or unintuitive behavior. Therefore, it is important to understand the properties of message execution. Potential security issues that arise in this model, such as reentrancy bugs, are discussed in the [security best practices on inter-canister calls](/docs/building-apps/security/inter-canister-calls).
 
 The [community conversation on security best practices](https://www.youtube.com/watch?v=PneRzDmf_Xw&list=PLuhDt1vhGcrez-f3I0_hvbwGZHZzkZ7Ng&index=2&t=4s) also discusses the messaging properties.
 


### PR DESCRIPTION
Updated the link to the security best practices on inter-canister calls.

Thank you for your contribution to the IC Developer Portal. This repo contains the content for https://internetcomputer.org and the ICP Developer Documentation, https://internetcomputer.org/docs/. 

If you are submitting a pull request for adding or changing content on the ICP Developer Documentation, please make sure that your contribution meets the following requirements:

- [ ] Follows the [developer docs style guide](https://github.com/dfinity/portal/blob/master/style-guide.md).
- [ ] Follows the [best practices and guidelines](https://github.com/dfinity/portal/tree/master?tab=readme-ov-file#best-practices).
- [ ] New documentation pages include [document tags](https://github.com/dfinity/portal/tree/master?tab=readme-ov-file#document-tags).
- [ ] New documentation pages include [SEO keywords](https://github.com/dfinity/portal/tree/master?tab=readme-ov-file#seo-keywords).
- [ ] New documents are in the `.mdx` file format to support the previous two components. 
- [ ] New documents are registered in [`/sidebars.js`](https://github.com/dfinity/portal/blob/master/sidebars.js), otherwise, it will not appear in the
  side navigation bar.
- [ ] Make sure that the [`.github/CODEOWNERS`](https://github.com/dfinity/portal/blob/master/.github/CODEOWNERS) file is
contains any new directories or specific documents that you added that should be reviewed by a specific teamm.
