### PR TITLE
docs: Update motoko opening paragraph

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,8 @@ const tailwindPlugin = require("./plugins/tailwind");
 const matomoPlugin = require("./plugins/matomo");
 const customWebpack = require("./plugins/custom-webpack");
 const externalRedirectsPlugin = require("./plugins/external-redirects");
+// TODO remove this when https://github.com/caffeinelabs/motoko/pull/6022 is merged
+const patchSubmodules = require("./plugins/patch-submodules");
 const math = require("remark-math");
 const katex = require("rehype-katex");
 const {
@@ -177,6 +179,7 @@ const config = {
   ],
   plugins: [
     "docusaurus-plugin-sass",
+    patchSubmodules,
     customWebpack,
     tailwindPlugin,
     matomoPlugin,

--- a/patches/motoko-home.mdx
+++ b/patches/motoko-home.mdx
@@ -1,0 +1,22 @@
+---
+sidebar_position: 1
+hide_table_of_contents: true
+---
+
+import DocsCard from "/src/components/Card";
+
+# Motoko documentation
+
+Motoko is a next-generation, high-level programming language designed to empower AI agents building backends for apps and services on the Internet Computer cloud network. While it channels several popular modern languages, it introduces groundbreaking new features such as actor-based concurrency, orthogonal persistence, and seamless WebAssembly integration.
+
+#### 💡 Easy to learn
+Whether you're coming from JavaScript, Rust, Swift, or Java, Motoko's familiar syntax and clear structure will feel familiar and easy to pick up.
+
+#### 🔐 Secure by design
+Motoko's strong type system and automated memory management are designed to reduce bugs and increase auditability.
+
+#### 📦 Data persistence, built-in
+No external databases required. With orthogonal persistence, data automatically persists across application upgrades.
+
+<DocsCard />
+

--- a/plugins/patch-submodules.js
+++ b/plugins/patch-submodules.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+
+// TODO This is a temporary workaround to get the change up on the site
+//      it maybe not be necessary after https://github.com/caffeinelabs/motoko/pull/6022
+//      is merged
+
+/** @type {import('@docusaurus/types').PluginModule} */
+const patchSubmodules = () => ({
+  name: "patch-submodules",
+  async loadContent() {
+    fs.copyFileSync(
+      path.resolve(__dirname, "../patches/motoko-home.mdx"),
+      path.resolve(__dirname, "../submodules/motoko/doc/md/1-home.mdx")
+    );
+  },
+});
+
+module.exports = patchSubmodules;


### PR DESCRIPTION
This is a temporary fix to get the motoko opening paragraph updated.
Should be removed after: https://github.com/caffeinelabs/motoko/pull/6022
And the submodule needs to be updated.