### PR TITLE
docs: make icp CLI primary, add deprecation banners for dfx pages

### DIFF
--- a/docs/building-apps/developer-tools/dev-tools-overview.mdx
+++ b/docs/building-apps/developer-tools/dev-tools-overview.mdx
@@ -1,5 +1,5 @@
 ---
-keywords: [beginner, developer tools, dev tools, overview]
+keywords: [beginner, developer tools, dev tools, overview, icp-cli, icp, dfx]
 ---
 
 import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
@@ -10,35 +10,40 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 Developer tools are used to create, manage, and interact with canisters. They can come in several formats, such as command line tools, onchain and off-chain libraries, and integrated development environments. For ICP developers, there are tools within each of these categories available for you to utilize when developing your ICP canisters.
 
-## Canister development kits (CDKs)
-
-A canister development kit (CDK) is an adapter used by `dfx` to provide programming languages with the necessary features and functionality to create, deploy, and manage canisters.
-
-[Motoko](/motoko/home) is ICP's native programming language. It is installed with the IC SDK.
-
-The [Rust CDK](/building-apps/developer-tools/cdks/rust/intro-to-rust) is developed and maintained by DFINITY for Rust development.
-
-There are several community-contributed and maintained CDKs for languages such as:
-
-- [icpp-pro](https://github.com/icppWorld/icpp-pro) - C++ CDK.
-
-- [Azle](https://github.com/demergent-labs/azle) - TypeScript CDK.
-
-- [Kybra](https://github.com/demergent-labs/kybra) - Python CDK.
-
-- [moonbit-ic-cdk](https://github.com/eliezhao/moonbit-ic-cdk) - MoonBit CDK.
-
 ## Command line tools
 
-### `dfx`
+### `icp` CLI (recommended)
 
-[`dfx`](/building-apps/developer-tools/dfx/) is the primary tool used by developers to create, build, deploy, manage, and call canisters. `dfx` is also referred to as the IC SDK, or the Internet Computer Software Development Kit.
+[`icp`](https://cli.internetcomputer.org) is the primary command-line tool for building and deploying applications on the Internet Computer. It is the successor to `dfx` and is the recommended tool for all new projects.
+
+Key capabilities:
+
+- Create, build, deploy, and manage canisters
+- Deploy to local development environments and mainnet
+- Manage developer identities and cycles
+- Full migration guide from `dfx` available at [cli.internetcomputer.org/docs/migration](https://cli.internetcomputer.org/docs/migration)
+
+- [Install `icp` CLI](/building-apps/getting-started/install#icp-cli-recommended).
+
+- [`icp` CLI documentation](https://cli.internetcomputer.org).
+
+- [icp-cli GitHub repo](https://github.com/dfinity/icp-cli).
+
+### `dfx` — legacy CLI
+
+:::caution
+
+`dfx` is the legacy CLI. New projects should use the [`icp` CLI](#icp-cli-recommended) above. Existing `dfx` projects can migrate using the [migration guide](https://cli.internetcomputer.org/docs/migration).
+
+:::
+
+[`dfx`](/building-apps/developer-tools/dfx/) was the primary tool used by developers to create, build, deploy, manage, and call canisters. `dfx` is also referred to as the IC SDK, or the Internet Computer Software Development Kit.
 
 `dfx` supports [local development](/building-apps/developing-canisters/deploy) and deployment through the [`dfx start`](/building-apps/developer-tools/dfx/) command, which runs a local development environment using [PocketIC](/building-apps/test/pocket-ic) that can be used to deploy and test canisters on your local machine.
 
 To deploy canisters to the mainnet or make calls to canisters already deployed on the mainnet, the `--network ic` flag can be used with most `dfx` commands.
 
-- [Install `dfx`](/building-apps/getting-started/install).
+- [Install `dfx`](/building-apps/getting-started/install#ic-sdk-dfx--legacy).
 
 - [`dfx` documentation](/building-apps/developer-tools/dfx/).
 
@@ -53,6 +58,24 @@ To deploy canisters to the mainnet or make calls to canisters already deployed o
 - [`dfxvm` documentation](/building-apps/developer-tools/dfxvm/dfxvm-default).
 
 - [`dfxvm` GitHub repo](https://github.com/dfinity/dfxvm).
+
+## Canister development kits (CDKs)
+
+A canister development kit (CDK) is an adapter used by the CLI to provide programming languages with the necessary features and functionality to create, deploy, and manage canisters.
+
+[Motoko](/motoko/home) is ICP's native programming language. It is installed with the IC SDK.
+
+The [Rust CDK](/building-apps/developer-tools/cdks/rust/intro-to-rust) is developed and maintained by DFINITY for Rust development.
+
+There are several community-contributed and maintained CDKs for languages such as:
+
+- [icpp-pro](https://github.com/icppWorld/icpp-pro) - C++ CDK.
+
+- [Azle](https://github.com/demergent-labs/azle) - TypeScript CDK.
+
+- [Kybra](https://github.com/demergent-labs/kybra) - Python CDK.
+
+- [moonbit-ic-cdk](https://github.com/eliezhao/moonbit-ic-cdk) - MoonBit CDK.
 
 ## ICP Ninja
 

--- a/docs/building-apps/getting-started/install.mdx
+++ b/docs/building-apps/getting-started/install.mdx
@@ -1,5 +1,5 @@
 ---
-keywords: [beginner, getting started, tutorial, tools, installing tools, install dfx, dfx, dfxvm, setup dfx, setup environment, install]
+keywords: [beginner, getting started, tutorial, tools, installing tools, install icp, icp-cli, icp, install dfx, dfx, dfxvm, setup dfx, setup environment, install]
 hide_table_of_contents: true
 ---
 
@@ -9,17 +9,49 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 import { GlossaryTooltip } from "/src/components/Tooltip/GlossaryTooltip";
 import { OsType, useOs } from "/src/hooks/useOs";
 
-# Install the IC SDK
+# Install developer tools
 
 <MarkdownChipRow labels={["Beginner", "Getting started"]} />
 
-The IC SDK is a software development kit used to develop applications on your local machine and to deploy them to ICP. It is natively supported on Linux or macOS 12.\* Monterey and newer. Windows users can use the IC SDK with Windows Subsystem for Linux (WSL 2).
-
-:::danger
+:::tip
 
 If you followed a [quick start](/building-apps/getting-started/quickstart) guide, you can skip this step.
 
 :::
+
+## icp CLI (recommended)
+
+`icp` is the primary command-line tool for building and deploying applications on the Internet Computer. It is the successor to `dfx` and is the recommended tool for all new projects.
+
+```bash
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
+```
+
+For Motoko projects, also install the Motoko package manager:
+
+```bash
+npm install -g ic-mops
+```
+
+Confirm installation:
+
+```bash
+icp --version
+```
+
+Full documentation and additional install methods (Homebrew, shell script) are available at **[cli.internetcomputer.org](https://cli.internetcomputer.org)**.
+
+---
+
+## IC SDK (`dfx`) — legacy
+
+:::caution
+
+`dfx` is the legacy CLI. New projects should use the [`icp` CLI](#icp-cli-recommended) above. If you have an existing `dfx` project, see the [dfx → icp migration guide](https://cli.internetcomputer.org/docs/migration).
+
+:::
+
+The IC SDK is natively supported on Linux or macOS 12.\* Monterey and newer. Windows users can use the IC SDK with Windows Subsystem for Linux (WSL 2).
 
 <AdornedTabs defaultValue={useOs().current}>
 <TabItem value={OsType.Linux} label="Linux">

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,6 +96,10 @@ const subnavItems = [
         docId: "other/updates/release-notes/release-notes",
       },
       {
+        label: "icp CLI",
+        href: "https://cli.internetcomputer.org",
+      },
+      {
         label: "Awesome Internet Computer",
         href: "https://github.com/dfinity/awesome-internet-computer#readme",
       },

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import { useLocation } from '@docusaurus/router';
+
+const DfxDeprecationBanner = () => (
+  <div
+    style={{
+      background: '#fff3cd',
+      border: '1px solid #ffc107',
+      borderRadius: '4px',
+      padding: '12px 16px',
+      marginBottom: '16px',
+      fontSize: '14px',
+      lineHeight: '1.5',
+    }}
+  >
+    <strong>⚠️ Heads up:</strong> <code>dfx</code> is the legacy CLI.{' '}
+    New projects should use the{' '}
+    <a href="https://cli.internetcomputer.org"><strong>icp CLI</strong></a>{' '}
+    instead.{' '}
+    <a href="https://cli.internetcomputer.org/docs/migration">
+      View the dfx → icp migration guide →
+    </a>
+  </div>
+);
+
+export default function LayoutWrapper(props) {
+  const { pathname } = useLocation();
+  const isDfxPage = pathname.includes('/developer-tools/dfx');
+
+  return (
+    <>
+      {isDfxPage && <DfxDeprecationBanner />}
+      <Layout {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This PR fixes the P0 docs issue identified in the ICP presence audit: every new developer landing on `docs.internetcomputer.org` was being routed through the legacy `dfx` CLI with no mention of `icp`.

### Changes

- **`install.mdx`** — `icp` CLI is now the primary install path (`npm install -g @icp-sdk/icp-cli`); `dfx` moved to a clearly-labelled `## IC SDK (dfx) — legacy` section with a caution admonition and link to the migration guide
- **`dev-tools-overview.mdx`** — added `icp` CLI section first with "recommended" framing; demoted `dfx` section to legacy with caution admonition linking to `cli.internetcomputer.org/docs/migration`; CDK section description de-coupled from `dfx`-specific wording
- **`docusaurus.config.js`** — added `cli.internetcomputer.org` as the first item in the Resources nav dropdown so the `icp` CLI is discoverable from every docs page
- **`src/theme/DocItem/Layout/index.js`** — new Docusaurus theme swizzle that injects a deprecation banner on every `/developer-tools/dfx/*` page: "⚠️ Heads up: `dfx` is the legacy CLI. New projects should use the icp CLI instead. View the dfx → icp migration guide →"

### What this fixes

| Before | After |
|--------|-------|
| Install page: `dfx install` / `dfx --version` as primary, no `icp` mention | Install page: `icp` CLI primary at top; `dfx` demoted to legacy section |
| dev-tools-overview: `dfx` described as "the primary tool", `icp-cli` not listed | dev-tools-overview: `icp` CLI listed first as recommended; `dfx` as legacy |
| Every `dfx` command page: no deprecation notice | Every `dfx/*` page: yellow banner → icp CLI + migration guide |
| Resources nav: no link to `cli.internetcomputer.org` | Resources nav: `icp CLI` link added |

### Note on dfx command reference pages

The `dfx` command reference pages (e.g. `dfx deploy`, `dfx canister`, etc.) live in the `submodules/sdk` git submodule. The deprecation banner injected via `DocItem/Layout` covers all of these pages without requiring changes to the submodule.

## Test plan

- [ ] `yarn build` passes without errors
- [ ] `/building-apps/getting-started/install` shows `icp` CLI section before `dfx` section
- [ ] `/building-apps/developer-tools/dev-tools-overview` shows `icp` CLI section first with recommended tag
- [ ] Any `/building-apps/developer-tools/dfx/*` page shows the yellow deprecation banner
- [ ] Resources dropdown in nav includes `icp CLI` link to `cli.internetcomputer.org`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)