### PR TITLE
fix: pin cbor2<6 to fix preview deployment workflow

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.10"
       - run: |
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          pip install icp-py-core
+          pip install icp-py-core "cbor2<6"
           python3 .github/workflows/scripts/release-canister.py $pull_number
         env:
           ICP_IDENTITY_PREVIEW: ${{ secrets.DFX_IDENTITY_PREVIEW }}

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -49,7 +49,7 @@ jobs:
 
           # request preview canister from the pool
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          pip install icp-py-core
+          pip install icp-py-core "cbor2<6"
           canister_id=$(python3 .github/workflows/scripts/request-canister.py $pull_number)
 
           # Create icp-cli canister ID mapping for ic environment


### PR DESCRIPTION
## Summary

- `cbor2 6.0.0` was released on 2026-04-28 as a major Rust rewrite, breaking CBOR decoding in `icp-py-core`'s `icp_agent` library
- `icp-py-core` depends on `cbor2>=5.6.0` (no upper bound), so it auto-picks up the breaking 6.x release
- This caused the PR Preview Deployment and PR Cleanup workflows to fail with `RuntimeError: v4 /call returned HTTP 200 with non-CBOR body` since April 28
- Fix: pin `cbor2<6` at install time in both affected workflows until `icp-py-core` adds proper support for `cbor2 6.x`