### PR TITLE
docs: add EdDSA/Ed25519 to allowed WebAuthn signature schemes

### DIFF
--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,11 +1,5 @@
 ## Changelog {#changelog}
 
-### 0.61.0 (2026-05-11) {$0_61_0}
-* WebAuthn signatures may use EdDSA on curve Ed25519, in addition to ECDSA P-256 (SHA-256)
-  and RSA PKCS#1v1.5 (SHA-256). The corresponding COSE public key encoding is
-  `kty=OKP`, `alg=EdDSA`, `crv=Ed25519`. EdDSA signatures are the raw 64-byte
-  `R || s` concatenation defined in RFC 8032 §5.1.6 (not DER-wrapped).
-
 ### 0.60.0 (2025-05-04) {$0_60_0}
 * Canister signatures from canisters on subnets of type `cloud_engine` are not valid.
 * New HTTP endpoints for update calls (to create a canister by subnet admins) and

--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,11 @@
 ## Changelog {#changelog}
 
+### 0.61.0 (2026-05-11) {$0_61_0}
+* WebAuthn signatures may use EdDSA on curve Ed25519, in addition to ECDSA P-256 (SHA-256)
+  and RSA PKCS#1v1.5 (SHA-256). The corresponding COSE public key encoding is
+  `kty=OKP`, `alg=EdDSA`, `crv=Ed25519`. EdDSA signatures are the raw 64-byte
+  `R || s` concatenation defined in RFC 8032 §5.1.6 (not DER-wrapped).
+
 ### 0.60.0 (2025-05-04) {$0_60_0}
 * Canister signatures from canisters on subnets of type `cloud_engine` are not valid.
 * New HTTP endpoints for update calls (to create a canister by subnet admins) and

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -350,6 +350,8 @@ The allowed signature schemes for web authentication are
 
 -   [**RSA PKCS\#1v1.5 (RSASSA-PKCS1-v1\_5)**](https://datatracker.ietf.org/doc/html/rfc8017#section-8.2), using SHA-256 as hash function.
 
+-   [**EdDSA**](https://datatracker.ietf.org/doc/html/rfc8032) on curve Ed25519.
+
 The signature is calculated by using the payload as the challenge in the web authentication assertion.
 
 The signature is checked by verifying that the `challenge` field contains the [base64url encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-5) of the payload, and that `signature` verifies on `authenticatorData · SHA-256(utf8(clientDataJSON))`, as specified in the [WebAuthn w3c recommendation](https://www.w3.org/TR/webauthn/#op-get-assertion).
@@ -382,7 +384,7 @@ You can also view the wrapping in [an online ASN.1 JavaScript decoder](https://l
 
     -   `client_data_json` (`text`): WebAuthn client data in JSON representation.
 
-    -   `signature` (`blob`): Signature as specified in the [WebAuthn w3c recommendation](https://www.w3.org/TR/webauthn/#signature-attestation-types), which means DER encoding in the case of an ECDSA signature.
+    -   `signature` (`blob`): Signature as specified in the [WebAuthn w3c recommendation](https://www.w3.org/TR/webauthn/#signature-attestation-types), which means DER encoding in the case of an ECDSA signature, and the 64-byte concatenation `R || s` as defined in [RFC 8032, Section 5.1.6](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6) in the case of an EdDSA signature on curve Ed25519.
 
 #### Canister signatures {#canister-signatures}
 


### PR DESCRIPTION
## Summary

Update the IC interface specification to allow EdDSA on curve Ed25519 as a third WebAuthn signature scheme (alongside ECDSA P-256 and RSA PKCS#1v1.5), mirroring the implementation change in dfinity/ic#10081.

## Changes

- `docs/references/ic-interface-spec.md` §Web Authentication: add `EdDSA on curve Ed25519` to the allowed-schemes list; clarify the signature encoding note to call out that Ed25519 WebAuthn signatures are the raw 64-byte `R || s` concatenation from RFC 8032 §5.1.6 (not DER-wrapped, which only applies to ECDSA).
- `docs/references/_attachments/interface-spec-changelog.md`: new entry. The version number (0.61.0) is a placeholder — happy to adjust to whatever the maintainers prefer.

## Context

Was triggered by the implementation work in dfinity/ic#10081 to accept Ed25519 WebAuthn keys (e.g. NitroKey 3A authenticators emit `kty=OKP / alg=EdDSA / crv=Ed25519`). Reviewer @eichhorl asked whether there's a corresponding spec PR — this is it.