### PR TITLE
feat: allow PATCH in `http_request` for non-replicated calls

### DIFF
--- a/docs/references/_attachments/ic.did
+++ b/docs/references/_attachments/ic.did
@@ -344,7 +344,7 @@ type deposit_cycles_args = record {
 type http_request_args = record {
     url : text;
     max_response_bytes : opt nat64;
-    method : variant { get; head; post; put; delete };
+    method : variant { get; head; post; put; delete; patch };
     headers : vec http_header;
     body : opt blob;
     transform : opt record {

--- a/docs/references/_attachments/interface-spec-changelog.md
+++ b/docs/references/_attachments/interface-spec-changelog.md
@@ -1,5 +1,8 @@
 ## Changelog {#changelog}
 
+### 0.62.0 (2025-06-03) {$0_62_0}
+* Support for the HTTP method `PATCH` in canister `http_request` in non-replicated mode.
+
 ### 0.61.0 (2025-05-18) {$0_61_0}
 * New management canister endpoint `canister_metrics`.
 

--- a/docs/references/ic-interface-spec.md
+++ b/docs/references/ic-interface-spec.md
@@ -3046,7 +3046,7 @@ In the replicated mode, the responses for all identical requests must match, too
 
 For this reason, the calling canister can supply a transformation function, which the IC uses to let the canister sanitize the responses from such unique values. The transformation function is executed separately on the corresponding response received for a request (both in replicated and non-replicated modes). Only the transformed response will be available to the calling canister.
 
-Currently, the `GET`, `HEAD`, and `POST` methods are supported for HTTP requests. Additionally, the `PUT` and `DELETE` methods are supported in non-replicated mode only. `PUT` and `DELETE` are restricted to non-replicated mode to avoid confusing race conditions that may occur with replicated execution.
+Currently, the `GET`, `HEAD`, and `POST` methods are supported for HTTP requests. Additionally, the `PUT`, `DELETE`, and `PATCH` methods are supported in non-replicated mode only. `PUT`, `DELETE`, and `PATCH` are restricted to non-replicated mode to avoid confusing race conditions that may occur with replicated execution.
 
 It is important to note the following for the usage of the `POST` method:
 
@@ -3070,7 +3070,7 @@ The following parameters should be supplied for the call:
 
 -   `max_response_bytes` - optional, specifies the maximal size of the response in bytes. If provided, the value must not exceed `2MB` (`2,000,000B`). The call will be charged based on this parameter. If not provided, the maximum of `2MB` will be used.
 
--   `method` - currently, `GET`, `HEAD`, and `POST` are supported. Additionally, `PUT` and `DELETE` are supported in non-replicated mode only.
+-   `method` - currently, `GET`, `HEAD`, and `POST` are supported. Additionally, `PUT`, `DELETE`, and `PATCH` are supported in non-replicated mode only.
 
 -   `headers` - list of HTTP request headers and their corresponding values
 


### PR DESCRIPTION
Resolves #6244.

Adds the `PATCH` HTTP method to the canister `http_request` (HTTPS outcalls) management-canister interface, mirroring the `PUT`/`DELETE` addition in #6199.

### What

- `ic.did`: `method` variant → `variant { get; head; post; put; delete; patch }`.
- `ic-interface-spec.md`: document `PATCH` alongside `PUT`/`DELETE` as supported in **non-replicated mode only**.
- `interface-spec-changelog.md`: new `0.62.0` entry.

### Why

`PATCH` is pervasive in modern REST APIs for partial updates (Google Calendar, GitHub, Stripe, …). It is currently the only common verb missing after `PUT`/`DELETE` landed, which blocks canisters from calling those endpoints. The concrete driver is a generated Motoko client for the Google Calendar API, whose partial-update operations (`events.patch`, `calendars.patch`, `acl.patch`, `calendarList.patch`) are otherwise un-callable.

### Why non-replicated only

Same rationale as `PUT`/`DELETE`: in replicated mode an outcall is issued once per replica, so a mutation would hit the remote N times, and mutation responses rarely agree byte-for-byte across replicas. `PATCH` additionally is not guaranteed idempotent (RFC 5789 §2) — it is idempotent only for field-merge bodies — which makes the non-replicated restriction even more appropriate. The existing `is_replicated` machinery already covers it; no new mechanism is introduced.

### Notes

- Spec/docs change only. The corresponding runtime implementation lives in `dfinity/ic`.
- Draft pending the runtime side / IC-team review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
