### PR TITLE
chore: Update CODEOWNERS: merge infrasec/prodsec into security team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,11 +23,11 @@ docs/defi/chain-key-tokens/ @dfinity/defi @dfinity/editorial
 docs/building-apps/chain-fusion/ @dfinity/defi @dfinity/editorial
 
 # ProdSec
-docs/building-apps/security/ @dfinity/product-security @dfinity/editorial
-docs/building-apps/best-practices/idempotency.mdx @dfinity/product-security @dfinity/editorial
-docs/references/advanced-ingress-messages.mdx @dfinity/product-security @dfinity/editorial
-docs/references/message-execution-properties.mdx @dfinity/product-security @dfinity/editorial
-src/pages/security-advisories.tsx @dfinity/product-security @dfinity/editorial
+docs/building-apps/security/ @dfinity/security @dfinity/editorial
+docs/building-apps/best-practices/idempotency.mdx @dfinity/security @dfinity/editorial
+docs/references/advanced-ingress-messages.mdx @dfinity/security @dfinity/editorial
+docs/references/message-execution-properties.mdx @dfinity/security @dfinity/editorial
+src/pages/security-advisories.tsx @dfinity/security @dfinity/editorial
 
 # Execution
 docs/references/execution-errors.mdx @dfinity/team-dsm @dfinity/editorial


### PR DESCRIPTION
The infrasec and prodsec security teams have been merged into a single `security` team.

This PR updates CODEOWNERS to replace references to the old teams with the merged team:
- `@dfinity/infrasec` -> `@dfinity/security`
- `@dfinity/product-security` / `@dfinity/prodsec` -> `@dfinity/security`

Other owners, file paths, alignment and comments are preserved. Generated automatically.