### PR TITLE
Remove security team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,13 +22,6 @@ docs/defi/token-ledgers/cycles-ledger.mdx @dfinity/defi @dfinity/sdk @dfinity/ed
 docs/defi/chain-key-tokens/ @dfinity/defi @dfinity/editorial
 docs/building-apps/chain-fusion/ @dfinity/defi @dfinity/editorial
 
-# ProdSec
-docs/building-apps/security/ @dfinity/editorial
-docs/building-apps/best-practices/idempotency.mdx @dfinity/editorial
-docs/references/advanced-ingress-messages.mdx @dfinity/editorial
-docs/references/message-execution-properties.mdx @dfinity/editorial
-src/pages/security-advisories.tsx @dfinity/editorial
-
 # Execution
 docs/references/execution-errors.mdx @dfinity/team-dsm @dfinity/editorial
 docs/building-apps/interact-with-canisters/advanced-calls.mdx @dfinity/team-dsm @dfinity/editorial

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,11 +23,11 @@ docs/defi/chain-key-tokens/ @dfinity/defi @dfinity/editorial
 docs/building-apps/chain-fusion/ @dfinity/defi @dfinity/editorial
 
 # ProdSec
-docs/building-apps/security/ @dfinity/product-security @dfinity/editorial
-docs/building-apps/best-practices/idempotency.mdx @dfinity/product-security @dfinity/editorial
-docs/references/advanced-ingress-messages.mdx @dfinity/product-security @dfinity/editorial
-docs/references/message-execution-properties.mdx @dfinity/product-security @dfinity/editorial
-src/pages/security-advisories.tsx @dfinity/product-security @dfinity/editorial
+docs/building-apps/security/ @dfinity/editorial
+docs/building-apps/best-practices/idempotency.mdx @dfinity/editorial
+docs/references/advanced-ingress-messages.mdx @dfinity/editorial
+docs/references/message-execution-properties.mdx @dfinity/editorial
+src/pages/security-advisories.tsx @dfinity/editorial
 
 # Execution
 docs/references/execution-errors.mdx @dfinity/team-dsm @dfinity/editorial


### PR DESCRIPTION
Removes the entire `# ProdSec` section (5 `@dfinity/product-security` rules + comment) from `.github/CODEOWNERS`.

These paths are already owned by `@dfinity/editorial` via the top-level `* @dfinity/editorial` rule, so effective ownership is unchanged.